### PR TITLE
[FDORA-129] feat: 응답형식 및 예외 처리 방식 설정

### DIFF
--- a/src/main/java/com/farmdora/farmdora/common/exception/CustomException.java
+++ b/src/main/java/com/farmdora/farmdora/common/exception/CustomException.java
@@ -1,0 +1,8 @@
+package com.farmdora.farmdora.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class CustomException extends RuntimeException {
+    abstract public HttpStatus getStatus();
+    abstract public String getMessage();
+}

--- a/src/main/java/com/farmdora/farmdora/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/farmdora/farmdora/common/exception/GlobalExceptionHandler.java
@@ -1,12 +1,10 @@
 package com.farmdora.farmdora.common.exception;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Configuration
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/src/main/java/com/farmdora/farmdora/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/farmdora/farmdora/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.farmdora.farmdora.common.exception;
+
+import com.farmdora.farmdora.common.response.HttpResponse;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Configuration
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> customExceptionHandler(CustomException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new HttpResponse(e.getStatus(), e.getMessage(), null));
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/common/response/ErrorMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/ErrorMessage.java
@@ -1,0 +1,12 @@
+package com.farmdora.farmdora.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessage {
+    ORDER_NOT_FOUND("존재하지 않는 주문입니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/farmdora/farmdora/common/response/HttpResponse.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/HttpResponse.java
@@ -1,0 +1,21 @@
+package com.farmdora.farmdora.common.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class HttpResponse {
+    private int status;
+    private String message;
+    private Object data;
+
+    public HttpResponse (HttpStatus status, String message, Object data) {
+        this.status = status.value();
+        this.message = message;
+        this.data = data;
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- [x] 응답형식 설정
- [x] 예외 처리 방식(GlobalExceptionHandler) 설정

<br/>

## 💡 필수확인 GlobalExceptionHandler & CustomException
```java
orderRepository.findById(1)
    .orElseThrow(() -> new OrderNotFoundException());   // CustomExcepion을 상속한 사용자 정의 예외 클래스
```
위와 같이 CustomException을 상속한 예외 클래스를 발생시켰을 경우 GlobalExceptionHandler에서 해당 예외를 잡아서 응답클래스인 HttpResponse를 구성하고 아래와 같이 클라이언트로 리턴해줍니다.

<img width="1002" alt="스크린샷 2025-04-05 오후 4 18 11" src="https://github.com/user-attachments/assets/aff10e99-6946-4f80-bcbd-0f19f6f463cb" />


## 📷 스크린샷(선택)

<br><br>
## ✅ 참고 사항(선택)

