### PR TITLE
[FDORA-39] feat: 상품 목록 검색 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SuccessMessage {
-    SEARCH_ORDER_SUCCESS("주문 목록 조회에 성공하였습니다.");
+    SEARCH_ORDER_SUCCESS("주문 목록 조회에 성공하였습니다."),
+    SEARCH_SALES_SUCCESS("상품 목록 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/entity/Option.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Option.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,7 +29,7 @@ public class Option {
     @Column(name = "option_id")
     private Integer id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "type_id")
     private OptionType type;
 

--- a/src/main/java/com/farmdora/farmdora/entity/Order.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Order.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/farmdora/farmdora/entity/ReviewFile.java
+++ b/src/main/java/com/farmdora/farmdora/entity/ReviewFile.java
@@ -31,9 +31,7 @@ public class ReviewFile {
     @JoinColumn(name = "review_id")
     private Review review;
 
-    @Column(nullable = false)
     private String originFile;
 
-    @Column(nullable = false)
     private String saveFile;
 }

--- a/src/main/java/com/farmdora/farmdora/order/mapper/OrderMapper.java
+++ b/src/main/java/com/farmdora/farmdora/order/mapper/OrderMapper.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrderMapper {
 
-    public PageResponseDto<OrderSearchResponseDto> toDto(Page<OrderDto> orders, List<OrderDetailDto> orderDetails) {
+    public PageResponseDto<OrderSearchResponseDto> mapToOrderSearchResponseDto(Page<OrderDto> orders, List<OrderDetailDto> orderDetails) {
         List<OrderSearchResponseDto> orderSearchResponseDtos = toOrderList(orders);
         Map<Integer, OrderSearchResponseDto> orderMap = toOrderMap(orderSearchResponseDtos);
 

--- a/src/main/java/com/farmdora/farmdora/order/repository/CustomOrderRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/order/repository/CustomOrderRepositoryImpl.java
@@ -103,8 +103,6 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
                 .orderBy(ordersOrderBy(sort))
                 .fetch();
 
-        log.info("주문 상세 데이터: {}", orderDetails);
-
         return orderDetails;
     }
 

--- a/src/main/java/com/farmdora/farmdora/order/service/OrderService.java
+++ b/src/main/java/com/farmdora/farmdora/order/service/OrderService.java
@@ -29,9 +29,9 @@ public class OrderService {
         List<OrderDetailDto> orderDetails = null;
         if (!orderIds.isEmpty()) {
             orderDetails = orderRepository.findOrderDetailsByIds(orderIds, searchCondition.getSort());
-            return orderMapper.toDto(orders, orderDetails);
+            return orderMapper.mapToOrderSearchResponseDto(orders, orderDetails);
         }
 
-        return orderMapper.toDto(orders, null);
+        return orderMapper.mapToOrderSearchResponseDto(orders, null);
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -1,0 +1,47 @@
+package com.farmdora.farmdora.sale.controller;
+
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
+
+import com.farmdora.farmdora.common.response.HttpResponse;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.service.SaleService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/my/seller/sale")
+@RequiredArgsConstructor
+public class SaleController {
+    private final SaleService saleService;
+
+    @PostMapping("/search")
+    public ResponseEntity<?> searchWithJson(@RequestBody SaleSearchRequestDto searchCondition) {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        log.info("상품 목록 검색: {}", searchCondition);
+        Pageable pageable = searchCondition.toPageable();
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(searchCondition.getSellerId(), searchCondition, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> searchWithParams(SaleSearchRequestDto searchCondition) {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        log.info("상품 목록 검색: {}", searchCondition);
+        Pageable pageable = searchCondition.toPageable();
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(searchCondition.getSellerId(), searchCondition, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleSearchRequestDto.java
@@ -35,7 +35,7 @@ public class SaleSearchRequestDto {
     private Integer page = 0;
 
     public Pageable toPageable() {
-        final int size = 10;
+        final int size = 15;
         if (this.page != null) {
             return PageRequest.of(this.page, size);
         }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleSearchRequestDto.java
@@ -1,0 +1,44 @@
+package com.farmdora.farmdora.sale.dto;
+
+import com.farmdora.farmdora.order.dto.Sort;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleSearchRequestDto {
+    private Integer sellerId;
+    private String keyword;
+
+    @Builder.Default
+    private Sort sort = Sort.LATEST;
+
+    @Builder.Default
+    private Set<SaleStatus> filters = new HashSet<>();
+
+    private Short typeBigId;
+    private Short typeId;
+
+    @Builder.Default
+    private Integer page = 0;
+
+    public Pageable toPageable() {
+        final int size = 10;
+        if (this.page != null) {
+            return PageRequest.of(this.page, size);
+        }
+        return PageRequest.of(0, size);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleSearchResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleSearchResponseDto.java
@@ -1,0 +1,18 @@
+package com.farmdora.farmdora.sale.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleSearchResponseDto {
+    private int saleId;
+    private String title;
+    private int price;
+    private boolean isBlind;
+    private int stock;
+    private Long orderCount;
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleStatus.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleStatus.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.sale.dto;
+
+public enum SaleStatus {
+    INSTOCK, PREORDER
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/querydsl/SaleDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/querydsl/SaleDto.java
@@ -1,0 +1,26 @@
+package com.farmdora.farmdora.sale.dto.querydsl;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+public class SaleDto {
+    private int saleId;
+    private String title;
+    private boolean isBlind;
+    private int price;
+    private int stock;
+
+    @QueryProjection
+    public SaleDto(int saleId, String title, boolean isBlind, int price, int stock) {
+        this.saleId = saleId;
+        this.title = title;
+        this.isBlind = isBlind;
+        this.price = price;
+        this.stock = stock;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/querydsl/SaleOrderCountDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/querydsl/SaleOrderCountDto.java
@@ -1,0 +1,20 @@
+package com.farmdora.farmdora.sale.dto.querydsl;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+public class SaleOrderCountDto {
+    private Integer saleId;
+    private Long orderCount;
+
+    @QueryProjection
+    public SaleOrderCountDto(Integer saleId, Long orderCount) {
+        this.saleId = saleId;
+        this.orderCount = orderCount;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/mapper/SaleMapper.java
+++ b/src/main/java/com/farmdora/farmdora/sale/mapper/SaleMapper.java
@@ -1,0 +1,48 @@
+package com.farmdora.farmdora.sale.mapper;
+
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SaleMapper {
+
+    public List<SaleSearchResponseDto> mapToSaleSearchResponseDto(List<Integer> saleIds, List<SaleDto> sales, List<SaleOrderCountDto> orderCounts) {
+        Map<Integer, SaleDto> saleMap = new HashMap<>();
+        for (SaleDto sale : sales) {
+            saleMap.put(sale.getSaleId(), sale);
+        }
+
+        Map<Integer, Long> orderCountMap = new HashMap<>();
+        for (SaleOrderCountDto count : orderCounts) {
+            orderCountMap.put(count.getSaleId(), count.getOrderCount());
+        }
+
+        List<SaleSearchResponseDto> saleSearchResult = new ArrayList<>();
+        for (Integer saleId : saleIds) {
+            SaleSearchResponseDto dto = new SaleSearchResponseDto();
+
+            if (saleMap.containsKey(saleId)) {
+                SaleDto sale = saleMap.get(saleId);
+                dto.setSaleId(sale.getSaleId());
+                dto.setTitle(sale.getTitle());
+                dto.setBlind(sale.isBlind());
+                dto.setPrice(sale.getPrice());
+                dto.setStock(sale.getStock());
+            }
+
+            Long orderCount = orderCountMap.getOrDefault(saleId, 0L);
+            dto.setOrderCount(orderCount);
+
+            saleSearchResult.add(dto);
+        }
+
+        return saleSearchResult;
+    }
+
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepository.java
@@ -1,0 +1,13 @@
+package com.farmdora.farmdora.sale.repository;
+
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomSaleRepository {
+    Page<SaleDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable);
+    List<SaleOrderCountDto> searchSaleOrderCount(List<Integer> saleIds);
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryImpl.java
@@ -1,0 +1,139 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static com.farmdora.farmdora.entity.QOption.option;
+import static com.farmdora.farmdora.entity.QOptionType.optionType;
+import static com.farmdora.farmdora.entity.QOptionTypeBig.optionTypeBig;
+import static com.farmdora.farmdora.entity.QOrderOption.orderOption;
+import static com.farmdora.farmdora.entity.QSale.sale;
+
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.QSaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.QSaleOrderCountDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class CustomSaleRepositoryImpl implements CustomSaleRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CustomSaleRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<SaleDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
+        List<SaleDto> sales = queryFactory
+                .select(
+                        new QSaleDto(sale.id, sale.title, sale.isBlind, option.price.min(), option.quantity.sum())
+                )
+                .from(sale)
+                .join(option).on(option.sale.eq(sale))
+                .join(optionType).on(option.type.eq(optionType))
+                .join(optionTypeBig).on(optionType.optionTypeBig.eq(optionTypeBig))
+                .where(
+                        sale.seller.id.eq(sellerId),
+                        titleContains(searchCondition.getKeyword()),
+                        isBlindEq(searchCondition.getFilters()),
+                        isSmallTypeEq(searchCondition.getTypeId()),
+                        isBigTypeEq(searchCondition.getTypeBigId())
+                )
+                .groupBy(sale.id, sale.title, sale.isBlind, sale.createdDate)
+                .orderBy(salesOrderBy(searchCondition.getSort()), sale.id.desc())
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        JPAQuery<Long> countQuery = createCountQuery(sellerId, searchCondition);
+
+        return PageableExecutionUtils.getPage(sales, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public List<SaleOrderCountDto> searchSaleOrderCount(List<Integer> saleIds) {
+        return queryFactory
+                .select(new QSaleOrderCountDto(sale.id, orderOption.id.count()))
+                .from(orderOption)
+                .join(option).on(option.id.eq(orderOption.option.id))
+                .where(sale.id.in(saleIds))
+                .groupBy(sale.id)
+                .fetch();
+    }
+
+    private JPAQuery<Long> createCountQuery(Integer sellerId, SaleSearchRequestDto searchCondition) {
+        return queryFactory
+                .select(sale.countDistinct())
+                .from(sale)
+                .join(option).on(option.sale.eq(sale))
+                .join(optionType).on(option.type.eq(optionType))
+                .join(optionTypeBig).on(optionType.optionTypeBig.eq(optionTypeBig))
+                .where(
+                        sale.seller.id.eq(sellerId),
+                        titleContains(searchCondition.getKeyword()),
+                        isBlindEq(searchCondition.getFilters()),
+                        isSmallTypeEq(searchCondition.getTypeId()),
+                        isBigTypeEq(searchCondition.getTypeBigId())
+                );
+    }
+
+    private BooleanExpression titleContains(String keyword) {
+        if (StringUtils.hasText(keyword)) {
+            return sale.title.contains(keyword);
+        }
+        return null;
+    }
+
+    private BooleanExpression isBlindEq(Set<SaleStatus> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return null;
+        }
+
+        boolean hasInstock = filters.contains(SaleStatus.INSTOCK);
+        boolean hasPreorder = filters.contains(SaleStatus.PREORDER);
+
+        if (hasPreorder && hasInstock) {
+            return null;
+        } else if (hasPreorder) {
+            return sale.isBlind.isTrue();
+        } else if (hasInstock) {
+            return sale.isBlind.isFalse();
+        }
+        return null;
+    }
+
+    private BooleanExpression isSmallTypeEq(Short typeId) {
+        if (typeId != null) {
+            return option.type.id.eq(typeId);
+        }
+        return null;
+    }
+
+    private BooleanExpression isBigTypeEq(Short typeBigId) {
+        if (typeBigId != null) {
+            return option.type.optionTypeBig.id.eq(typeBigId);
+        }
+        return null;
+    }
+
+    private OrderSpecifier<?> salesOrderBy(Sort sort) {
+        if (sort.equals(Sort.OLDEST)) {
+            return sale.createdDate.asc();
+        } else {
+            return sale.createdDate.desc();
+        }
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
@@ -1,0 +1,7 @@
+package com.farmdora.farmdora.sale.repository;
+
+import com.farmdora.farmdora.entity.Sale;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SaleRepository extends JpaRepository<Sale, Integer>, CustomSaleRepository {
+}

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -1,0 +1,50 @@
+package com.farmdora.farmdora.sale.service;
+
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.mapper.SaleMapper;
+import com.farmdora.farmdora.sale.repository.SaleRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SaleService {
+    private final SaleRepository saleRepository;
+    private final SaleMapper saleMapper;
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<SaleSearchResponseDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
+        Page<SaleDto> salePage = saleRepository.searchSales(sellerId, searchCondition, pageable);
+        List<SaleDto> sales = salePage.getContent();
+        List<Integer> saleIds = getSaleIds(sales);
+        List<SaleOrderCountDto> orderCounts = getOrderCounts(saleIds);
+        List<SaleSearchResponseDto> saleSearchResponseDtos = saleMapper.mapToSaleSearchResponseDto(saleIds, sales, orderCounts);
+
+        return new PageResponseDto<>(saleSearchResponseDtos, salePage);
+    }
+
+    private List<SaleOrderCountDto> getOrderCounts(List<Integer> saleIds) {
+        List<SaleOrderCountDto> orderCounts = new ArrayList<>();
+        if (!saleIds.isEmpty()) {
+            orderCounts = saleRepository.searchSaleOrderCount(saleIds);
+        }
+        return orderCounts;
+    }
+
+    private List<Integer> getSaleIds(List<SaleDto> sales) {
+        return sales
+                .stream()
+                .map(SaleDto::getSaleId)
+                .toList();
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/ControllerTest.java
@@ -1,0 +1,26 @@
+package com.farmdora.farmdora;
+
+import com.farmdora.farmdora.order.controller.OrderController;
+import com.farmdora.farmdora.order.service.OrderService;
+import com.farmdora.farmdora.sale.controller.SaleController;
+import com.farmdora.farmdora.sale.service.SaleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {
+        OrderController.class,
+        SaleController.class
+})
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mvc;
+
+    @MockitoBean
+    protected OrderService orderService;
+
+    @MockitoBean
+    protected SaleService saleService;
+}

--- a/src/test/java/com/farmdora/farmdora/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/order/controller/OrderControllerTest.java
@@ -9,29 +9,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.farmdora.farmdora.ControllerTest;
+import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.order.dto.OrderSearchRequestDto;
 import com.farmdora.farmdora.order.dto.OrderSearchResponseDto;
-import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.order.service.OrderService;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = OrderController.class)
-class OrderControllerTest {
-
-    @MockitoBean
-    private OrderService orderService;
-
-    @Autowired
-    private MockMvc mvc;
+class OrderControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("판매자 주문목록 조회 API 테스트")

--- a/src/test/java/com/farmdora/farmdora/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/order/repository/OrderRepositoryTest.java
@@ -33,8 +33,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Import(AuditConfig.class)
 @Transactional
+@Import(AuditConfig.class)
 class OrderRepositoryTest {
 
     @Autowired
@@ -202,10 +202,6 @@ class OrderRepositoryTest {
         List<OrderDetailDto> orderDetails = orderRepository.findOrderDetailsByIds(orderIds, Sort.LATEST);
 
         // then
-        OrderDetailDto orderDetail = orderDetails.get(0);
-        assertThat(orderDetail.getOrderId()).isEqualTo(10);
-        assertThat(orderDetail.getSaleId()).isEqualTo(1);
-        assertThat(orderDetail.getSaleTitle()).isEqualTo("고구마");
-        assertThat(orderDetail.getOptionId()).isEqualTo(1);
+        assertThat(orderDetails.size()).isEqualTo(30);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/order/service/OrderServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/order/service/OrderServiceTest.java
@@ -88,7 +88,7 @@ class OrderServiceTest {
                 new OrderSearchResponseDto()
         ));
         PageResponseDto<OrderSearchResponseDto> pageResponseDto = new PageResponseDto<>(orderSearchResponseDtos, pages);
-        when(orderMapper.toDto(any(Page.class), anyList())).thenReturn(pageResponseDto);
+        when(orderMapper.mapToOrderSearchResponseDto(any(Page.class), anyList())).thenReturn(pageResponseDto);
 
         // when
         PageResponseDto<OrderSearchResponseDto> result = orderService

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -1,0 +1,100 @@
+package com.farmdora.farmdora.sale.controller;
+
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.farmdora.farmdora.ControllerTest;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+
+class SaleControllerTest extends ControllerTest {
+
+    private SaleSearchRequestDto searchCondition;
+    private PageResponseDto<SaleSearchResponseDto> result;
+
+    @BeforeEach
+    void setUp() {
+        searchCondition  = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeBigId((short) 1)
+                .typeId((short) 2)
+                .build();
+
+        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
+                SaleSearchResponseDto.builder()
+                        .saleId(1)
+                        .title("상추1")
+                        .price(10000)
+                        .isBlind(false)
+                        .stock(100)
+                        .orderCount(3L)
+                        .build(),
+                SaleSearchResponseDto.builder()
+                        .saleId(2)
+                        .title("상추2")
+                        .price(20000)
+                        .isBlind(false)
+                        .stock(200)
+                        .orderCount(2L)
+                        .build()
+        );
+        Page<SaleSearchResponseDto> pages = new PageImpl<>(saleSearchResponseDtos);
+        result = new PageResponseDto(pages.getContent(), pages);
+    }
+
+    @Test
+    @DisplayName("JSON으로 상품 목록 조회 API 테스트")
+    void testSearchSalesByJsonAPI() throws Exception {
+        // given
+        when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+        // when
+        // then
+        mvc.perform(post("/my/seller/sale/search")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(searchCondition)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+    }
+
+    @Test
+    @DisplayName("파라미터로 상품 목록 조회 API 테스트")
+    void testSearchSalesByParamsAPI() throws Exception {
+        // given
+        when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+        // when
+        // then
+        mvc.perform(get("/my/seller/sale/search")
+                        .param("keyword", "상추")
+                        .param("sort", "LATEST")
+                        .param("typeBigId", "1")
+                        .param("typeId", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/mapper/SaleMapperTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/mapper/SaleMapperTest.java
@@ -1,0 +1,41 @@
+package com.farmdora.farmdora.sale.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SaleMapperTest {
+
+    private final SaleMapper saleMapper = new SaleMapper();
+
+    @Test
+    @DisplayName("상품정보, 상품의 주문 수를 하나의 DTO로 매핑")
+    void testMapToSaleSearchResponseDto() {
+        // given
+        List<Integer> saleIds = new ArrayList<>();
+        List<SaleDto> sales = new ArrayList<>();
+        List<SaleOrderCountDto> orderCounts = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            saleIds.add(i);
+            sales.add(new SaleDto(i, "상추" + i, false, i * 1000, i * 100));
+            orderCounts.add(new SaleOrderCountDto(i, (long) i));
+        }
+
+        // when
+        List<SaleSearchResponseDto> result = saleMapper.mapToSaleSearchResponseDto(saleIds, sales, orderCounts);
+
+        // then
+        SaleSearchResponseDto saleDetail = result.get(0);
+        assertThat(saleDetail.getOrderCount()).isEqualTo(1);
+        assertThat(saleDetail.getTitle()).isEqualTo("상추1");
+        assertThat(saleDetail.getSaleId()).isEqualTo(1);
+        assertThat(saleDetail.getPrice()).isEqualTo(1000);
+        assertThat(saleDetail.getStock()).isEqualTo(100);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
@@ -1,0 +1,137 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.OptionType;
+import com.farmdora.farmdora.entity.OptionTypeBig;
+import com.farmdora.farmdora.entity.OrderOption;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Transactional
+@Import(AuditConfig.class)
+class SaleRepositoryTest {
+
+    @Autowired
+    private SaleRepository saleRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private Seller seller;
+    private OptionTypeBig bigType;
+    private OptionType smallType;
+
+    @BeforeEach
+    void setUp() {
+        seller = new Seller();
+        em.persist(seller);
+
+        bigType = OptionTypeBig.builder()
+                .id((short) 1)
+                .name("과일")
+                .build();
+        em.persist(bigType);
+
+        smallType = OptionType.builder()
+                .id((short) 1)
+                .name("사과")
+                .optionTypeBig(bigType)
+                .build();
+        em.persist(smallType);
+
+        for (int i = 0; i < 10; i++) {
+            Sale sale = Sale.builder()
+                    .title("상추" + (i + 1))
+                    .isBlind(false)
+                    .seller(seller)
+                    .build();
+            em.persist(sale);
+
+            Option option1 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .type(smallType)
+                    .sale(sale)
+                    .build();
+            Option option2 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .type(smallType)
+                    .sale(sale)
+                    .build();
+            em.persist(option1);
+            em.persist(option2);
+
+            OrderOption orderOption1 = OrderOption.builder()
+                    .option(option1)
+                    .build();
+            OrderOption orderOption2 = OrderOption.builder()
+                    .option(option2)
+                    .build();
+            em.persist(orderOption1);
+            em.persist(orderOption2);
+        }
+    }
+
+    @Test
+    @DisplayName("상품 목록 검색 및 조회 테스트")
+    void testSearchSales() {
+        // given
+        Integer sellerId = seller.getId();
+        System.out.println(sellerId);
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeBigId(bigType.getId())
+                .typeId(smallType.getId())
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<SaleDto> result = saleRepository.searchSales(sellerId, searchCondition, pageable);
+
+        // then
+        assertThat(result.getContent().size()).isEqualTo(10);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("상품 목록 주문 수 조회 테스트")
+    void testSearchOrderCounts() {
+        // given
+        List<Sale> sales = saleRepository.findAll();
+        List<Integer> saleIds = sales.stream().map(s -> s.getId()).collect(Collectors.toList());
+
+        // when
+        List<SaleOrderCountDto> orderCounts = saleRepository.searchSaleOrderCount(saleIds);
+
+        // then
+        assertThat(orderCounts.size()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -1,0 +1,114 @@
+package com.farmdora.farmdora.sale.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.sale.mapper.SaleMapper;
+import com.farmdora.farmdora.sale.repository.SaleRepository;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class SaleServiceTest {
+
+    @Mock
+    private SaleRepository saleRepository;
+
+    @Mock
+    private SaleMapper saleMapper;
+
+    @InjectMocks
+    private SaleService saleService;
+
+    @Test
+    @DisplayName("판매자의 상품 목록 검색 및 조회 서비스 레이어 테스트")
+    void testSearchSales() {
+        // given
+        List<SaleDto> saleDtos = List.of(
+                SaleDto.builder()
+                        .saleId(1)
+                        .title("상추1")
+                        .price(10000)
+                        .isBlind(false)
+                        .stock(100)
+                        .build(),
+                SaleDto.builder()
+                        .saleId(2)
+                        .title("상추2")
+                        .price(20000)
+                        .isBlind(false)
+                        .stock(200)
+                        .build()
+        );
+        Page<SaleDto> saleSearchResponsePages = new PageImpl<>(saleDtos);
+        when(saleRepository.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(saleSearchResponsePages);
+
+        List<SaleOrderCountDto> orderCounts = List.of(
+                SaleOrderCountDto.builder()
+                        .saleId(1)
+                        .orderCount(1L)
+                        .build(),
+                SaleOrderCountDto.builder()
+                        .saleId(2)
+                        .orderCount(1L)
+                        .build()
+        );
+        when(saleRepository.searchSaleOrderCount(anyList())).thenReturn(orderCounts);
+
+        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
+                SaleSearchResponseDto.builder()
+                        .saleId(1)
+                        .title("상추1")
+                        .price(10000)
+                        .isBlind(false)
+                        .stock(100)
+                        .orderCount(1L)
+                        .build(),
+                SaleSearchResponseDto.builder()
+                        .saleId(2)
+                        .title("상추2")
+                        .price(20000)
+                        .isBlind(false)
+                        .stock(200)
+                        .orderCount(2L)
+                        .build()
+        );
+        when(saleMapper.mapToSaleSearchResponseDto(anyList(), anyList(), anyList())).thenReturn(saleSearchResponseDtos);
+
+        // when
+        Integer sellerId = 1;
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeId((short) 1)
+                .typeBigId((short) 1)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(sellerId, searchCondition, pageable);
+
+        // then
+        assertThat(result.getContents().size()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- [x] 상품 목록 검색 및 조회 API 구현
- [x] 테스트 코드 작성
- [x] `Option` 엔티티 클래스 수정 : `OptionType`과의 관계를 `OneToOne` -> `ManyToOne`으로 수정
<br>

## 💡 필수확인 1
- @kjh1125 님의 요청으로 `GET`, `POST` 2개의 API로 구현


### 요청 데이터(POST)
- `sellerId` : 판매자 아이디
- `keyword` : 검색할 상품명
- `sort` : 정렬방법(`LATEST`/`OLDEST`)
- `filters` : 상품의 판매상태(`INSTOCK`=판매중, `PREORDER`=판매중지)
- `typeBigId` : 카테고리 대분류 아이디
- `typeId` : 카테고리 소분류 아이디
- `page` : 페이지 번호(0부터 시작)

```json
{
    "sellerId": 1,
    "keyword": "상추",
    "sort": "LATEST",
    "filters": ["INSTOCK"],
    "typeBigId": 2,
    "typeId": 6,
    "page": 100
}
```

### 응답 데이터
- `currentPage` : 현재 페이지 번호
- `pageSize` : 페이지 당 데이터 개수
- `totalElements` : 검색조건에 포함되는 전체 데이터 개수
- `totalPages` : 검색조건에 포함되는 전체 페이지 수
- `hasNext` : 다음 페이지 여부
- `hasPrevious` : 이전 페이지 여부
- `contents` : 검색한 데이터
  - `saleId` : 상품 아이디
  - `title` : 상품 제목
  - `stock` : 재고 수
  - `orderCount` : 주문 수
  - `blind` : 판매상태

```json
{
    "status": 200,
    "message": "상품 목록 조회에 성공하였습니다.",
    "data": {
        "currentPage": 99,
        "pageSize": 10,
        "totalElements": 999,
        "totalPages": 100,
        "hasNext": false,
        "hasPrevious": true,
        "contents": [
            {
                "saleId": 10,
                "title": "상추0000007",
                "price": 100,
                "stock": 200,
                "orderCount": 2,
                "blind": false
            },
            {
                "saleId": 9,
                "title": "상추0000006",
                "price": 90,
                "stock": 180,
                "orderCount": 2,
                "blind": false
            }
        ]
    }
}
```
<br>

## 💡 필수확인 1
`Option` 엔티티 클래스 수정 : `OptionType`과의 관계를 `OneToOne` -> `ManyToOne`으로 수정

<br/>

## 📷 스크린샷(선택)


## ✅ 참고 사항(선택)
