### PR TITLE
[FDORA-34] feat: 상품 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
     SEARCH_ORDER_SUCCESS("주문 목록 조회에 성공하였습니다."),
-    SEARCH_SALES_SUCCESS("상품 목록 조회에 성공하였습니다.");
+    SEARCH_SALES_SUCCESS("상품 목록 조회에 성공하였습니다."),
+    GET_SALE_DETAIL_SUCCESS("상품 상세 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/entity/Like.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Like.java
@@ -5,16 +5,20 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
 @Entity
+@Table(name = "`like`")
 public class Like {
 
     @Id

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -1,9 +1,11 @@
 package com.farmdora.farmdora.sale.controller;
 
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.service.SaleService;
@@ -13,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,5 +46,13 @@ public class SaleController {
         PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(searchCondition.getSellerId(), searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
+    }
+
+    @GetMapping("/{saleId}")
+    public ResponseEntity<?> getSaleDetail(Integer userId, @PathVariable("saleId") Integer saleId) {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        SaleDetailDto saleDetail = saleService.getSaleDetail(userId, saleId);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, GET_SALE_DETAIL_SUCCESS.getMessage(), saleDetail));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleDetailDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleDetailDto.java
@@ -1,0 +1,64 @@
+package com.farmdora.farmdora.sale.dto;
+
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleFile;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleDetailDto {
+
+    @Builder.Default
+    private List<String> files = new ArrayList<>();
+
+    private List<OptionDetailDto> options;
+
+    private String origin;
+    private boolean isLike;
+    private String content;
+
+    public static SaleDetailDto createSaleDetail(Sale sale, List<SaleFile> files, List<Option> options, boolean isLike) {
+        List<OptionDetailDto> optionDetails = options.stream()
+                .map(OptionDetailDto::createOptionDetail)
+                .toList();
+        List<String> images = files.stream()
+                .map(SaleFile::getSaveFile)
+                .collect(Collectors.toList());
+
+        return SaleDetailDto.builder()
+                .files(images)
+                .origin(sale.getOrigin())
+                 .isLike(isLike)
+                .options(optionDetails)
+                .content(sale.getContent())
+                .build();
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionDetailDto {
+        private Integer optionId;
+        private String optionName;
+        private Integer price;
+
+        public static OptionDetailDto createOptionDetail(Option option) {
+            return OptionDetailDto.builder()
+                    .optionId(option.getId())
+                    .optionName(option.getName())
+                    .price(option.getPrice())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/LikeRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/LikeRepository.java
@@ -1,0 +1,8 @@
+package com.farmdora.farmdora.sale.repository;
+
+import com.farmdora.farmdora.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Integer> {
+    boolean existsByUserIdAndSaleId(Integer userId, Integer saleId);
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/OptionRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/OptionRepository.java
@@ -1,0 +1,10 @@
+package com.farmdora.farmdora.sale.repository;
+
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Sale;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionRepository extends JpaRepository<Option, Integer> {
+    List<Option> findAllBySale(Sale sale);
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleFileRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleFileRepository.java
@@ -1,0 +1,10 @@
+package com.farmdora.farmdora.sale.repository;
+
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleFile;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SaleFileRepository extends JpaRepository<SaleFile, Integer> {
+    List<SaleFile> findAllBySale(Sale sale);
+}

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -1,11 +1,19 @@
 package com.farmdora.farmdora.sale.service;
 
+import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleFile;
+import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
 import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
 import com.farmdora.farmdora.sale.mapper.SaleMapper;
+import com.farmdora.farmdora.sale.repository.LikeRepository;
+import com.farmdora.farmdora.sale.repository.OptionRepository;
+import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +28,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class SaleService {
     private final SaleRepository saleRepository;
+    private final OptionRepository optionRepository;
+    private final SaleFileRepository saleFileRepository;
+    private final LikeRepository likeRepository;
     private final SaleMapper saleMapper;
 
     @Transactional(readOnly = true)
@@ -46,5 +57,21 @@ public class SaleService {
                 .stream()
                 .map(SaleDto::getSaleId)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public SaleDetailDto getSaleDetail(Integer userId, Integer saleId) {
+        Sale sale = saleRepository.findById(saleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sale", saleId));
+        List<Option> options = optionRepository.findAllBySale(sale);
+        List<SaleFile> saleImages = saleFileRepository.findAllBySale(sale);
+
+        if (userId == null) {
+            return SaleDetailDto.createSaleDetail(sale, saleImages, options, false);
+        }
+
+        boolean exists = likeRepository.existsByUserIdAndSaleId(userId, saleId);
+
+        return SaleDetailDto.createSaleDetail(sale, saleImages, options, exists);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -1,5 +1,6 @@
 package com.farmdora.farmdora.sale.controller;
 
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,8 +12,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.farmdora.farmdora.ControllerTest;
+import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleStatus;
@@ -21,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -64,37 +69,88 @@ class SaleControllerTest extends ControllerTest {
         result = new PageResponseDto(pages.getContent(), pages);
     }
 
-    @Test
-    @DisplayName("JSON으로 상품 목록 조회 API 테스트")
-    void testSearchSalesByJsonAPI() throws Exception {
-        // given
-        when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+    @Nested
+    @DisplayName("상품 목록 조회 API 테스트")
+    class SearchSales {
 
-        // when
-        // then
-        mvc.perform(post("/my/seller/sale/search")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(new ObjectMapper().writeValueAsString(searchCondition)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", equalTo(200)))
-                .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        @Test
+        @DisplayName("JSON으로 상품 목록 조회 API 테스트")
+        void testSearchSalesByJsonAPI() throws Exception {
+            // given
+            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+            // when
+            // then
+            mvc.perform(post("/my/seller/sale/search")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(new ObjectMapper().writeValueAsString(searchCondition)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        }
+
+        @Test
+        @DisplayName("파라미터로 상품 목록 조회 API 테스트")
+        void testSearchSalesByParamsAPI() throws Exception {
+            // given
+            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+            // when
+            // then
+            mvc.perform(get("/my/seller/sale/search")
+                            .param("keyword", "상추")
+                            .param("sort", "LATEST")
+                            .param("typeBigId", "1")
+                            .param("typeId", "2"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        }
     }
 
-    @Test
-    @DisplayName("파라미터로 상품 목록 조회 API 테스트")
-    void testSearchSalesByParamsAPI() throws Exception {
-        // given
-        when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+    @Nested
+    @DisplayName("상품 상세 조회 API 테스트")
+    class GetSaleDetail {
 
-        // when
-        // then
-        mvc.perform(get("/my/seller/sale/search")
-                        .param("keyword", "상추")
-                        .param("sort", "LATEST")
-                        .param("typeBigId", "1")
-                        .param("typeId", "2"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", equalTo(200)))
-                .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        @Test
+        @DisplayName("상품 상세 조회 API 테스트")
+        void testGetSaleDetailAPI() throws Exception {
+            // given
+            SaleDetailDto saleDetailDto = SaleDetailDto.builder()
+                    .files(List.of("file1", "file2"))
+                    .options(List.of(new OptionDetailDto(), new OptionDetailDto()))
+                    .origin("국산")
+                    .isLike(true)
+                    .content("내용")
+                    .build();
+            when(saleService.getSaleDetail(anyInt(), anyInt())).thenReturn(saleDetailDto);
+
+            // when
+            // then
+            mvc.perform(get("/my/seller/sale/{saleId}", 1)
+                            .param("userId", "1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(GET_SALE_DETAIL_SUCCESS.getMessage())))
+                    .andExpect(jsonPath("$.data.files.size()", equalTo(2)))
+                    .andExpect(jsonPath("$.data.origin", equalTo("국산")));
+        }
+
+        @Test
+        @DisplayName("상품 상세 조회시 상품이 존재하지 않을 경우 예외 발생 API 테스트")
+        void testGetSaleDetailAPI_SaleNotFoundException() throws Exception {
+            // given
+            when(saleService.getSaleDetail(anyInt(), anyInt())).thenThrow(new ResourceNotFoundException("Sale", 1));
+
+            // when
+            // then
+            mvc.perform(get("/my/seller/sale/{saleId}", 1)
+                            .param("userId", "1"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("Sale 데이터가 존재하지 않습니다 : '1'")));
+        }
     }
+
+
 }

--- a/src/test/java/com/farmdora/farmdora/sale/repository/LikeRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/LikeRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.entity.Like;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class LikeRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private LikeRepository likeRepository;
+
+    @Test
+    @DisplayName("existsByUserIdAndSaleId 쿼리 메서드 테스트")
+    void testExistsByUserIdAndSaleId() {
+        // given
+        Like like1 = Like.builder()
+                .userId(1)
+                .saleId(1)
+                .build();
+        Like like2 = Like.builder()
+                .userId(2)
+                .saleId(1)
+                .build();
+        em.persist(like1);
+        em.persist(like2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        boolean like = likeRepository.existsByUserIdAndSaleId(1, 1);
+
+        // then
+        assertThat(like).isEqualTo(true);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/OptionRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/OptionRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Sale;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class OptionRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private OptionRepository optionRepository;
+
+    @Test
+    @DisplayName("findAllBySale 쿼리메서드 테스트")
+    void testFindAllBySale() {
+        // given
+        Sale sale = new Sale();
+        em.persist(sale);
+
+        Option option1 = Option.builder()
+                .sale(sale)
+                .build();
+        em.persist(option1);
+
+        Option option2 = Option.builder()
+                .sale(sale)
+                .build();
+        em.persist(option2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<Option> options = optionRepository.findAllBySale(sale);
+
+        // then
+        assertThat(options.size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleFileRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleFileRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleFile;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+class SaleFileRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private SaleFileRepository saleFileRepository;
+
+    @Test
+    @DisplayName("findAllBySale 쿼리 메서드 테스트")
+    void testFindAllBySale() {
+        // given
+        Sale sale = new Sale();
+        em.persist(sale);
+
+        SaleFile saleFile1 = SaleFile.builder()
+                .sale(sale)
+                .saveFile("file1")
+                .build();
+        SaleFile saleFile2 = SaleFile.builder()
+                .sale(sale)
+                .saveFile("file1")
+                .build();
+        em.persist(saleFile1);
+        em.persist(saleFile2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<SaleFile> saleFiles = saleFileRepository.findAllBySale(sale);
+
+        // then
+        assertThat(saleFiles.size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -1,21 +1,31 @@
 package com.farmdora.farmdora.sale.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
+import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleStatus;
 import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
 import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
 import com.farmdora.farmdora.sale.mapper.SaleMapper;
+import com.farmdora.farmdora.sale.repository.LikeRepository;
+import com.farmdora.farmdora.sale.repository.OptionRepository;
+import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +43,15 @@ class SaleServiceTest {
 
     @Mock
     private SaleRepository saleRepository;
+
+    @Mock
+    private OptionRepository optionRepository;
+
+    @Mock
+    private SaleFileRepository saleFileRepository;
+
+    @Mock
+    private LikeRepository likeRepository;
 
     @Mock
     private SaleMapper saleMapper;
@@ -110,5 +129,68 @@ class SaleServiceTest {
 
         // then
         assertThat(result.getContents().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("상품 상세 정보 조회 서비스 레이어 테스트")
+    void testGetSaleDetail() {
+        // given
+        Sale mockSale = Sale.builder()
+                .id(1)
+                .title("상추")
+                .content("유기농 상추")
+                .origin("국산")
+                .build();
+        when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
+
+        List<Option> options = List.of(
+                Option.builder()
+                        .id(1)
+                        .sale(mockSale)
+                        .name("상추 옵션1")
+                        .price(1000)
+                        .build(),
+                Option.builder()
+                        .id(2)
+                        .sale(mockSale)
+                        .name("상추 옵션2")
+                        .price(2000)
+                        .build()
+        );
+        when(optionRepository.findAllBySale(any(Sale.class))).thenReturn(options);
+
+        List<SaleFile> saleFiles = List.of(
+                SaleFile.builder()
+                        .sale(mockSale)
+                        .saveFile("URL1")
+                        .build(),
+                SaleFile.builder()
+                        .sale(mockSale)
+                        .saveFile("URL2")
+                        .build()
+        );
+        when(saleFileRepository.findAllBySale(any(Sale.class))).thenReturn(saleFiles);
+
+        when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
+
+        // when
+        SaleDetailDto saleDetail = saleService.getSaleDetail(1, 1);
+
+        // then
+        assertThat(saleDetail.getContent()).isEqualTo("유기농 상추");
+        assertThat(saleDetail.getOptions().size()).isEqualTo(2);
+        assertThat(saleDetail.getFiles().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("상세정보를 조회하고자 하는 상품이 존재하지 않을 경우 예외 발생테스트")
+    void testGetSaleDetail_SaleNotFoundException() {
+        // given
+        when(saleRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> saleService.getSaleDetail(1, 1))
+                .isInstanceOf(ResourceNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
- [x] 상품 상세 조회 API 구현
- [x] 테스트 코드 작성

<br>

## 💡 필수확인 1. Like 엔티티 예약어 회피
`User`, `Order`, `Option`과 같이 `Like` 엔티티도 예약어 충돌이 있어 `Like` 엔티티를 사용하시는 분들은 수정해주시기 바랍니다.
```java
@Entity
@Table(name = "`like`")
public class Like {
    // ...
}
```

## 💡 필수확인 2. API

### 요청 URL
`/my/seller/sale/1`

### 요청 파라미터
- userId : 사용자의 아이디(시큐리티 구현 후 수정 예정)
- saleId : 조회할 상품의 아이디(Path Variable)

### 성공 응답
```json
{
    "status": 200,
    "message": "상품 상세 조회에 성공하였습니다.",
    "data": {
        "files": [
            "file1",
            "file2",
            "file3",
            "file4",
            "file5"
        ],
        "options": [
            {
                "optionId": 16,
                "optionName": "상추0000010",
                "price": 100
            },
            {
                "optionId": 1039,
                "optionName": "상추0000010",
                "price": 100
            }
        ],
        "origin": "대한민국",
        "content": "직접 재배한 상추입니다.0000007",
        "like": false
    }
}
```

### 실패 응답
상품이 존재하지 않을 경우
```json
{
    "status": 400,
    "message": "Sale 데이터가 존재하지 않습니다 : '10000'",
    "data": null
}
```

<br>

## 📆 작업기간
2025.04.15
<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)