### PR TITLE
[FDORA-35] feat: 관련 상품 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum SuccessMessage {
     SEARCH_ORDER_SUCCESS("주문 목록 조회에 성공하였습니다."),
     SEARCH_SALES_SUCCESS("상품 목록 조회에 성공하였습니다."),
-    GET_SALE_DETAIL_SUCCESS("상품 상세 조회에 성공하였습니다.");
+    GET_SALE_DETAIL_SUCCESS("상품 상세 조회에 성공하였습니다."),
+    GET_RELATED_SALES_SUCCESS("관련 상품 목록 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -1,23 +1,20 @@
 package com.farmdora.farmdora.sale.controller;
 
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
-import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
-import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.service.SaleService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,5 +30,15 @@ public class SaleController {
         SaleDetailDto saleDetail = saleService.getSaleDetail(userId, saleId);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALE_DETAIL_SUCCESS.getMessage(), saleDetail));
+    }
+
+    @GetMapping("/related/{saleId}")
+    public ResponseEntity<?> getRelatedSales(Integer userId,
+                                             @PathVariable("saleId") Integer saleId,
+                                             @PageableDefault Pageable pageable) {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        List<SaleRelatedDto> relatedSales = saleService.getRelatedSales(userId, saleId, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, GET_RELATED_SALES_SUCCESS.getMessage(), relatedSales));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
@@ -1,11 +1,9 @@
 package com.farmdora.farmdora.sale.controller;
 
-import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.service.SaleService;
@@ -15,23 +13,35 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
-@RequestMapping("/sale")
+@RequestMapping("/my/seller/sale")
 @RequiredArgsConstructor
-public class SaleController {
+public class SellerSaleController {
     private final SaleService saleService;
 
-    @GetMapping("/{saleId}")
-    public ResponseEntity<?> getSaleDetail(Integer userId, @PathVariable("saleId") Integer saleId) {
+    @PostMapping("/search")
+    public ResponseEntity<?> searchWithJson(@RequestBody SaleSearchRequestDto searchCondition) {
         // TODO 스프링 시큐리티 구현 후 userId 가져오기
-        SaleDetailDto saleDetail = saleService.getSaleDetail(userId, saleId);
+        log.info("상품 목록 검색: {}", searchCondition);
+        Pageable pageable = searchCondition.toPageable();
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(searchCondition.getSellerId(), searchCondition, pageable);
         return ResponseEntity.ok()
-                .body(new HttpResponse(HttpStatus.OK, GET_SALE_DETAIL_SUCCESS.getMessage(), saleDetail));
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> searchWithParams() {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder().build();
+        Pageable pageable = searchCondition.toPageable();
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(1, searchCondition, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedDto.java
@@ -1,0 +1,31 @@
+package com.farmdora.farmdora.sale.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleRelatedDto {
+    private Integer saleId;
+    private String image;
+    private String saleTitle;
+    private Integer price;
+    private Double score;
+    private Long reviewCount;
+    private boolean isLike;
+
+    public static SaleRelatedDto createSaleRelatedDto(SaleRelatedInfoDto saleInfo, String mainImage, boolean isLike) {
+        return SaleRelatedDto.builder()
+                .saleId(saleInfo.getSaleId())
+                .image(mainImage)
+                .saleTitle(saleInfo.getTitle())
+                .price(saleInfo.getPrice())
+                .score(saleInfo.getScore())
+                .reviewCount(saleInfo.getReviewCount())
+                .isLike(isLike)
+                .build();
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedInfoDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedInfoDto.java
@@ -1,0 +1,22 @@
+package com.farmdora.farmdora.sale.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleRelatedInfoDto {
+    private Integer saleId;
+    private String title;
+    private Integer price;
+    private Double score;
+    private Long reviewCount;
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleFileRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleFileRepository.java
@@ -3,8 +3,10 @@ package com.farmdora.farmdora.sale.repository;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SaleFileRepository extends JpaRepository<SaleFile, Integer> {
     List<SaleFile> findAllBySale(Sale sale);
+    Optional<SaleFile> findBySaleIdAndIsMainIsTrue(Integer saleId);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
@@ -1,7 +1,28 @@
 package com.farmdora.farmdora.sale.repository;
 
 import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleType;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SaleRepository extends JpaRepository<Sale, Integer>, CustomSaleRepository {
+
+    @Query("SELECT new com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto(s.id, s.title, MIN(o.price), AVG(r.score), COUNT(r)) " +
+            "FROM Sale s " +
+            "LEFT JOIN Review r ON r.sale = s " +
+            "LEFT JOIN Option o ON o.sale = s " +
+            "WHERE s.type = :type " +
+            "AND s.id <> :excludedId " +
+            "GROUP BY s.id, s.title " +
+            "ORDER BY s.id DESC")
+    List<SaleRelatedInfoDto> findTop10SalesWithReviewCountByTypeAndExcludedId(
+            @Param("type") SaleType type,
+            @Param("excludedId") Integer excludedId,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -6,6 +6,8 @@ import com.farmdora.farmdora.entity.Option;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
@@ -17,12 +19,16 @@ import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -32,6 +38,12 @@ public class SaleService {
     private final SaleFileRepository saleFileRepository;
     private final LikeRepository likeRepository;
     private final SaleMapper saleMapper;
+
+    @Value("${ncp.image.path}")
+    private String imagePath;
+
+    @Value("${ncp.image.type}")
+    private String type;
 
     @Transactional(readOnly = true)
     public PageResponseDto<SaleSearchResponseDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
@@ -73,5 +85,36 @@ public class SaleService {
         boolean exists = likeRepository.existsByUserIdAndSaleId(userId, saleId);
 
         return SaleDetailDto.createSaleDetail(sale, saleImages, options, exists);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SaleRelatedDto> getRelatedSales(Integer userId, Integer saleId, Pageable pageable) {
+        Sale sale = saleRepository.findById(saleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sale", saleId));
+
+        List<SaleRelatedInfoDto> relatedSaleDetails = saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(sale.getType(), saleId, pageable);
+        List<SaleRelatedDto> relatedSales = getRelatedSalesMainImageAndIsLike(userId, relatedSaleDetails);
+
+        log.info("관련 상품 목록: {}", relatedSales);
+
+        return relatedSales;
+    }
+
+    private List<SaleRelatedDto> getRelatedSalesMainImageAndIsLike(Integer userId, List<SaleRelatedInfoDto> relatedSaleDetails) {
+        List<SaleRelatedDto> relatedSales = new ArrayList<>();
+        for (SaleRelatedInfoDto relatedSale : relatedSaleDetails) {
+            boolean isLike = likeRepository.existsByUserIdAndSaleId(userId, relatedSale.getSaleId());
+            Optional<SaleFile> saleFile = saleFileRepository.findBySaleIdAndIsMainIsTrue(relatedSale.getSaleId());
+            relatedSales.add(SaleRelatedDto.createSaleRelatedDto(relatedSale, getMainImage(saleFile), isLike));
+        }
+        return relatedSales;
+    }
+
+    private String getMainImage(Optional<SaleFile> saleFile) {
+        String mainImage = null;
+        if (saleFile.isPresent()) {
+            mainImage = String.format("%s%s%s", imagePath, saleFile.get().getSaveFile(), type);
+        }
+        return mainImage;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+ncp:
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png

--- a/src/test/java/com/farmdora/farmdora/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/ControllerTest.java
@@ -3,6 +3,7 @@ package com.farmdora.farmdora;
 import com.farmdora.farmdora.order.controller.OrderController;
 import com.farmdora.farmdora.order.service.OrderService;
 import com.farmdora.farmdora.sale.controller.SaleController;
+import com.farmdora.farmdora.sale.controller.SellerSaleController;
 import com.farmdora.farmdora.sale.service.SaleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {
         OrderController.class,
+        SellerSaleController.class,
         SaleController.class
 })
 public abstract class ControllerTest {

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -1,119 +1,34 @@
 package com.farmdora.farmdora.sale.controller;
 
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
-import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
-import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
-import com.farmdora.farmdora.sale.dto.SaleStatus;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import java.util.List;
-import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.MediaType;
 
-class SaleControllerTest extends ControllerTest {
-
-    private SaleSearchRequestDto searchCondition;
-    private PageResponseDto<SaleSearchResponseDto> result;
-
-    @BeforeEach
-    void setUp() {
-        searchCondition  = SaleSearchRequestDto.builder()
-                .keyword("상추")
-                .sort(Sort.LATEST)
-                .filters(Set.of(SaleStatus.INSTOCK))
-                .typeBigId((short) 1)
-                .typeId((short) 2)
-                .build();
-
-        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
-                SaleSearchResponseDto.builder()
-                        .saleId(1)
-                        .title("상추1")
-                        .price(10000)
-                        .isBlind(false)
-                        .stock(100)
-                        .orderCount(3L)
-                        .build(),
-                SaleSearchResponseDto.builder()
-                        .saleId(2)
-                        .title("상추2")
-                        .price(20000)
-                        .isBlind(false)
-                        .stock(200)
-                        .orderCount(2L)
-                        .build()
-        );
-        Page<SaleSearchResponseDto> pages = new PageImpl<>(saleSearchResponseDtos);
-        result = new PageResponseDto(pages.getContent(), pages);
-    }
-
-    @Nested
-    @DisplayName("상품 목록 조회 API 테스트")
-    class SearchSales {
-
-        @Test
-        @DisplayName("JSON으로 상품 목록 조회 API 테스트")
-        void testSearchSalesByJsonAPI() throws Exception {
-            // given
-            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
-
-            // when
-            // then
-            mvc.perform(post("/my/seller/sale/search")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(searchCondition)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
-        }
-
-        @Test
-        @DisplayName("파라미터로 상품 목록 조회 API 테스트")
-        void testSearchSalesByParamsAPI() throws Exception {
-            // given
-            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
-
-            // when
-            // then
-            mvc.perform(get("/my/seller/sale/search")
-                            .param("keyword", "상추")
-                            .param("sort", "LATEST")
-                            .param("typeBigId", "1")
-                            .param("typeId", "2"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
-        }
-    }
+public class SaleControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("상품 상세 조회 API 테스트")
     class GetSaleDetail {
 
         @Test
-        @DisplayName("상품 상세 조회 API 테스트")
+        @DisplayName("상품 상세 조회 API 성공")
         void testGetSaleDetailAPI() throws Exception {
             // given
             SaleDetailDto saleDetailDto = SaleDetailDto.builder()
@@ -127,7 +42,7 @@ class SaleControllerTest extends ControllerTest {
 
             // when
             // then
-            mvc.perform(get("/my/seller/sale/{saleId}", 1)
+            mvc.perform(get("/sale/{saleId}", 1)
                             .param("userId", "1"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
@@ -144,7 +59,7 @@ class SaleControllerTest extends ControllerTest {
 
             // when
             // then
-            mvc.perform(get("/my/seller/sale/{saleId}", 1)
+            mvc.perform(get("/sale/{saleId}", 1)
                             .param("userId", "1"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
@@ -152,5 +67,50 @@ class SaleControllerTest extends ControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("관련 상품 목록 조회 API 테스트")
+    class GetRelatedSales {
+        @Test
+        @DisplayName("관련 상품 목록 조회 API 성공")
+        void testGetRelatedSalesAPI() throws Exception {
+            // given
+            List<SaleRelatedDto> relatedSales = List.of(
+                    SaleRelatedDto.builder()
+                            .saleId(1)
+                            .isLike(true)
+                            .reviewCount(10L)
+                            .build(),
+                    SaleRelatedDto.builder()
+                            .saleId(1)
+                            .isLike(true)
+                            .reviewCount(10L)
+                            .build()
+            );
+            when(saleService.getRelatedSales(anyInt(), anyInt(), any(Pageable.class))).thenReturn(relatedSales);
 
+            // when
+            // then
+            mvc.perform(get("/sale/related/{saleId}", 1)
+                            .param("userId", "1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(GET_RELATED_SALES_SUCCESS.getMessage())))
+                    .andExpect(jsonPath("$.data.size()", equalTo(2)));
+        }
+
+        @Test
+        @DisplayName("관련 상품 목록 조회시 상품이 존재하지 않을 경우 예외 발생 API 테스트")
+        void testGetRelatedSalesAPI_SaleNotFoundException() throws Exception {
+            // given
+            when(saleService.getRelatedSales(anyInt(), anyInt(), any(Pageable.class))).thenThrow(new ResourceNotFoundException("Sale", 1));
+
+            // when
+            // then
+            mvc.perform(get("/sale/related/{saleId}", 1)
+                            .param("userId", "1"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("Sale 데이터가 존재하지 않습니다 : '1'")));
+        }
+    }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SellerSaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SellerSaleControllerTest.java
@@ -1,0 +1,106 @@
+package com.farmdora.farmdora.sale.controller;
+
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.farmdora.farmdora.ControllerTest;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+
+class SellerSaleControllerTest extends ControllerTest {
+
+    private SaleSearchRequestDto searchCondition;
+    private PageResponseDto<SaleSearchResponseDto> result;
+
+    @BeforeEach
+    void setUp() {
+        searchCondition  = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeBigId((short) 1)
+                .typeId((short) 2)
+                .build();
+
+        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
+                SaleSearchResponseDto.builder()
+                        .saleId(1)
+                        .title("상추1")
+                        .price(10000)
+                        .isBlind(false)
+                        .stock(100)
+                        .orderCount(3L)
+                        .build(),
+                SaleSearchResponseDto.builder()
+                        .saleId(2)
+                        .title("상추2")
+                        .price(20000)
+                        .isBlind(false)
+                        .stock(200)
+                        .orderCount(2L)
+                        .build()
+        );
+        Page<SaleSearchResponseDto> pages = new PageImpl<>(saleSearchResponseDtos);
+        result = new PageResponseDto(pages.getContent(), pages);
+    }
+
+    @Nested
+    @DisplayName("상품 목록 조회 API 테스트")
+    class SearchSales {
+
+        @Test
+        @DisplayName("JSON으로 상품 목록 조회 API 테스트")
+        void testSearchSalesByJsonAPI() throws Exception {
+            // given
+            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+            // when
+            // then
+            mvc.perform(post("/my/seller/sale/search")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(new ObjectMapper().writeValueAsString(searchCondition)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        }
+
+        @Test
+        @DisplayName("파라미터로 상품 목록 조회 API 테스트")
+        void testSearchSalesByParamsAPI() throws Exception {
+            // given
+            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+            // when
+            // then
+            mvc.perform(get("/my/seller/sale/search")
+                            .param("keyword", "상추")
+                            .param("sort", "LATEST")
+                            .param("typeBigId", "1")
+                            .param("typeId", "2"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        }
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.OrderOption;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleType;
+import com.farmdora.farmdora.entity.SaleTypeBig;
+import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Transactional
+@Import(AuditConfig.class)
+class CustomSaleRepositoryTest {
+
+    @Autowired
+    private SaleRepository saleRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private Seller seller;
+    private SaleTypeBig bigType;
+    private SaleType smallType;
+
+    @BeforeEach
+    void setUp() {
+        seller = new Seller();
+        em.persist(seller);
+
+        bigType = SaleTypeBig.builder()
+                .id((short) 1)
+                .name("과일")
+                .build();
+        em.persist(bigType);
+
+        smallType = SaleType.builder()
+                .id((short) 1)
+                .name("사과")
+                .saleTypeBig(bigType)
+                .build();
+        em.persist(smallType);
+
+        for (int i = 0; i < 10; i++) {
+            Sale sale = Sale.builder()
+                    .title("상추" + (i + 1))
+                    .isBlind(false)
+                    .seller(seller)
+                    .type(smallType)
+                    .build();
+            em.persist(sale);
+
+            Option option1 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .sale(sale)
+                    .build();
+            Option option2 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .sale(sale)
+                    .build();
+            em.persist(option1);
+            em.persist(option2);
+
+            OrderOption orderOption1 = OrderOption.builder()
+                    .option(option1)
+                    .build();
+            OrderOption orderOption2 = OrderOption.builder()
+                    .option(option2)
+                    .build();
+            em.persist(orderOption1);
+            em.persist(orderOption2);
+        }
+    }
+
+    @Test
+    @DisplayName("상품 목록 검색 및 조회 테스트")
+    void testSearchSales() {
+        // given
+        Integer sellerId = seller.getId();
+        System.out.println(sellerId);
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeBigId(bigType.getId())
+                .typeId(smallType.getId())
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<SaleDto> result = saleRepository.searchSales(sellerId, searchCondition, pageable);
+
+        // then
+        assertThat(result.getContent().size()).isEqualTo(10);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("상품 목록 주문 수 조회 테스트")
+    void testSearchOrderCounts() {
+        // given
+        List<Sale> sales = saleRepository.findAll();
+        List<Integer> saleIds = sales.stream().map(s -> s.getId()).collect(Collectors.toList());
+
+        // when
+        List<SaleOrderCountDto> orderCounts = saleRepository.searchSaleOrderCount(saleIds);
+
+        // then
+        assertThat(orderCounts.size()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleFileRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleFileRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,5 +47,35 @@ class SaleFileRepositoryTest {
 
         // then
         assertThat(saleFiles.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("findBySaleIdAndIsMainIsTrue() 쿼리메서드 테스트")
+    void testFindBySaleIdAndIsMainIsTrue() {
+        // given
+        Sale sale = new Sale();
+        em.persist(sale);
+
+        SaleFile saleFile1 = SaleFile.builder()
+                .sale(sale)
+                .isMain(false)
+                .build();
+        SaleFile saleFile2 = SaleFile.builder()
+                .sale(sale)
+                .saveFile("saveFile")
+                .isMain(true)
+                .build();
+        em.persist(saleFile1);
+        em.persist(saleFile2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<SaleFile> saleFile = saleFileRepository.findBySaleIdAndIsMainIsTrue(sale.getId());
+
+        // then
+        assertThat(saleFile.isPresent()).isEqualTo(true);
+        assertThat(saleFile.get().getSaveFile()).isEqualTo("saveFile");
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
@@ -2,36 +2,23 @@ package com.farmdora.farmdora.sale.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Like;
 import com.farmdora.farmdora.entity.Option;
-import com.farmdora.farmdora.entity.OrderOption;
+import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleType;
-import com.farmdora.farmdora.entity.SaleTypeBig;
-import com.farmdora.farmdora.entity.Seller;
-import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleStatus;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Transactional
-@Import(AuditConfig.class)
 class SaleRepositoryTest {
 
     @Autowired
@@ -40,97 +27,73 @@ class SaleRepositoryTest {
     @Autowired
     private TestEntityManager em;
 
-    private Seller seller;
-    private SaleTypeBig bigType;
-    private SaleType smallType;
+    @Test
+    @DisplayName("findTop10ByTypeAndIdNotOrderByIdDesc 쿼리메서드 테스트")
+    void testFindTop10ByTypeAndIdNotOrderByIdDesc() {
+        // given
+        User user = new User();
+        em.persist(user);
 
-    @BeforeEach
-    void setUp() {
-        seller = new Seller();
-        em.persist(seller);
-
-        bigType = SaleTypeBig.builder()
+        SaleType type = SaleType.builder()
                 .id((short) 1)
-                .name("과일")
+                .name("소분류1")
                 .build();
-        em.persist(bigType);
+        em.persist(type);
 
-        smallType = SaleType.builder()
-                .id((short) 1)
-                .name("사과")
-                .saleTypeBig(bigType)
+        Sale excludeSale = Sale.builder()
+                .type(type)
                 .build();
-        em.persist(smallType);
+        em.persist(excludeSale);
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 1; i <= 9; i++) {
             Sale sale = Sale.builder()
-                    .title("상추" + (i + 1))
-                    .isBlind(false)
-                    .seller(seller)
-                    .type(smallType)
+                    .title("title" + i)
+                    .type(type)
                     .build();
             em.persist(sale);
 
-            Option option1 = Option.builder()
-                    .price(100 * (i + 1))
-                    .quantity(100)
-                    .sale(sale)
-                    .build();
-            Option option2 = Option.builder()
-                    .price(100 * (i + 1))
-                    .quantity(100)
-                    .sale(sale)
-                    .build();
-            em.persist(option1);
-            em.persist(option2);
+            if (i % 2 == 0) {
+                Review review1 = Review.builder()
+                        .sale(sale)
+                        .score((byte) 3)
+                        .build();
+                Review review2 = Review.builder()
+                        .sale(sale)
+                        .score((byte) 4)
+                        .build();
+                em.persist(review1);
+                em.persist(review2);
+            } else {
+                Like like = Like.builder()
+                        .saleId(sale.getId())
+                        .userId(user.getUserId())
+                        .build();
+                em.persist(like);
 
-            OrderOption orderOption1 = OrderOption.builder()
-                    .option(option1)
-                    .build();
-            OrderOption orderOption2 = OrderOption.builder()
-                    .option(option2)
-                    .build();
-            em.persist(orderOption1);
-            em.persist(orderOption2);
+                Option option1 = Option.builder()
+                        .sale(sale)
+                        .price(1000)
+                        .build();
+                Option option2 = Option.builder()
+                        .sale(sale)
+                        .price(2000)
+                        .build();
+                em.persist(option1);
+                em.persist(option2);
+            }
         }
-    }
+        em.flush();
+        em.clear();
 
-    @Test
-    @DisplayName("상품 목록 검색 및 조회 테스트")
-    void testSearchSales() {
-        // given
-        Integer sellerId = seller.getId();
-        System.out.println(sellerId);
-        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
-                .keyword("상추")
-                .sort(Sort.LATEST)
-                .filters(Set.of(SaleStatus.INSTOCK))
-                .typeBigId(bigType.getId())
-                .typeId(smallType.getId())
-                .build();
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        Page<SaleDto> result = saleRepository.searchSales(sellerId, searchCondition, pageable);
+        List<SaleRelatedInfoDto> sales = saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(type, excludeSale.getId(), pageable);
+//        for (SaleRelatedInfoDto info : sales) {
+//            System.out.println(info.toString());
+//        }
 
         // then
-        assertThat(result.getContent().size()).isEqualTo(10);
-        assertThat(result.getTotalPages()).isEqualTo(1);
-        assertThat(result.getNumber()).isEqualTo(0);
-        assertThat(result.getTotalElements()).isEqualTo(10);
-    }
-
-    @Test
-    @DisplayName("상품 목록 주문 수 조회 테스트")
-    void testSearchOrderCounts() {
-        // given
-        List<Sale> sales = saleRepository.findAll();
-        List<Integer> saleIds = sales.stream().map(s -> s.getId()).collect(Collectors.toList());
-
-        // when
-        List<SaleOrderCountDto> orderCounts = saleRepository.searchSaleOrderCount(saleIds);
-
-        // then
-        assertThat(orderCounts.size()).isEqualTo(10);
+        assertThat(sales.size()).isEqualTo(9);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -12,8 +12,11 @@ import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.entity.Option;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
+import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleStatus;
@@ -28,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -131,66 +135,137 @@ class SaleServiceTest {
         assertThat(result.getContents().size()).isEqualTo(2);
     }
 
-    @Test
-    @DisplayName("상품 상세 정보 조회 서비스 레이어 테스트")
-    void testGetSaleDetail() {
-        // given
-        Sale mockSale = Sale.builder()
-                .id(1)
-                .title("상추")
-                .content("유기농 상추")
-                .origin("국산")
-                .build();
-        when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
+    @Nested
+    @DisplayName("판매자의 상품 목록 검색 및 조회 서비스 레이어 테스트")
+    class GetSaleDetailsTests {
 
-        List<Option> options = List.of(
-                Option.builder()
-                        .id(1)
-                        .sale(mockSale)
-                        .name("상추 옵션1")
-                        .price(1000)
-                        .build(),
-                Option.builder()
-                        .id(2)
-                        .sale(mockSale)
-                        .name("상추 옵션2")
-                        .price(2000)
-                        .build()
-        );
-        when(optionRepository.findAllBySale(any(Sale.class))).thenReturn(options);
+        @Test
+        @DisplayName("상품 상세 정보 조회 성공")
+        void testGetSaleDetail() {
+            // given
+            Sale mockSale = Sale.builder()
+                    .id(1)
+                    .title("상추")
+                    .content("유기농 상추")
+                    .origin("국산")
+                    .build();
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
 
-        List<SaleFile> saleFiles = List.of(
-                SaleFile.builder()
-                        .sale(mockSale)
-                        .saveFile("URL1")
-                        .build(),
-                SaleFile.builder()
-                        .sale(mockSale)
-                        .saveFile("URL2")
-                        .build()
-        );
-        when(saleFileRepository.findAllBySale(any(Sale.class))).thenReturn(saleFiles);
+            List<Option> options = List.of(
+                    Option.builder()
+                            .id(1)
+                            .sale(mockSale)
+                            .name("상추 옵션1")
+                            .price(1000)
+                            .build(),
+                    Option.builder()
+                            .id(2)
+                            .sale(mockSale)
+                            .name("상추 옵션2")
+                            .price(2000)
+                            .build()
+            );
+            when(optionRepository.findAllBySale(any(Sale.class))).thenReturn(options);
 
-        when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
+            List<SaleFile> saleFiles = List.of(
+                    SaleFile.builder()
+                            .sale(mockSale)
+                            .saveFile("URL1")
+                            .build(),
+                    SaleFile.builder()
+                            .sale(mockSale)
+                            .saveFile("URL2")
+                            .build()
+            );
+            when(saleFileRepository.findAllBySale(any(Sale.class))).thenReturn(saleFiles);
 
-        // when
-        SaleDetailDto saleDetail = saleService.getSaleDetail(1, 1);
+            when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
 
-        // then
-        assertThat(saleDetail.getContent()).isEqualTo("유기농 상추");
-        assertThat(saleDetail.getOptions().size()).isEqualTo(2);
-        assertThat(saleDetail.getFiles().size()).isEqualTo(2);
+            // when
+            SaleDetailDto saleDetail = saleService.getSaleDetail(1, 1);
+
+            // then
+            assertThat(saleDetail.getContent()).isEqualTo("유기농 상추");
+            assertThat(saleDetail.getOptions().size()).isEqualTo(2);
+            assertThat(saleDetail.getFiles().size()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("상세정보를 조회하고자 하는 상품이 존재하지 않을 경우 예외 발생테스트")
+        void testGetSaleDetail_SaleNotFoundException() {
+            // given
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> saleService.getSaleDetail(1, 1))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
     }
 
-    @Test
-    @DisplayName("상세정보를 조회하고자 하는 상품이 존재하지 않을 경우 예외 발생테스트")
-    void testGetSaleDetail_SaleNotFoundException() {
-        // given
-        when(saleRepository.findById(anyInt())).thenReturn(Optional.empty());
+    @Nested
+    @DisplayName("관련 상품 목록 조회 서비스 레이어 테스트")
+    class GetRelatedSales {
 
-        // when
-        // then
-        assertThatThrownBy(() -> saleService.getSaleDetail(1, 1))
-                .isInstanceOf(ResourceNotFoundException.class);
+        @Test
+        @DisplayName("관련 상품 목록 조회 성공")
+        void testGetRelatedSales() {
+            // given
+            Sale mockSale = Sale.builder()
+                    .id(1)
+                    .type(new SaleType())
+                    .build();
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
+
+            List<SaleRelatedInfoDto> relatedSaleDetails = List.of(
+                    SaleRelatedInfoDto.builder()
+                            .saleId(2)
+                            .title("sale2")
+                            .price(10000)
+                            .reviewCount(10L)
+                            .score(3.5)
+                            .build(),
+                    SaleRelatedInfoDto.builder()
+                            .saleId(3)
+                            .title("sale3")
+                            .price(20000)
+                            .reviewCount(12L)
+                            .score(4.0)
+                            .build()
+            );
+            when(saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(any(SaleType.class), anyInt(), any(Pageable.class))).thenReturn(relatedSaleDetails);
+
+            when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
+
+            SaleFile mockSaleFile = SaleFile.builder()
+                    .sale(mockSale)
+                    .isMain(true)
+                    .originFile("origin_file")
+                    .saveFile("save_file")
+                    .build();
+            when(saleFileRepository.findBySaleIdAndIsMainIsTrue(anyInt())).thenReturn(Optional.of(mockSaleFile));
+
+            // when
+            Pageable pageable = PageRequest.of(0, 10);
+            List<SaleRelatedDto> relatedSales = saleService.getRelatedSales(1, 1, pageable);
+
+            // then
+            assertThat(relatedSales.size()).isEqualTo(2);
+            assertThat(relatedSales.get(0).getSaleId()).isEqualTo(2);
+            assertThat(relatedSales.get(1).getSaleId()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("관련상품을 조회할 상품이 존재하지 않을 경우 예외 발생")
+        void testGetRelatedSales_ResourceNotFoundException() {
+            // given
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            Pageable pageable = PageRequest.of(0, 10);
+            assertThatThrownBy(() -> saleService.getRelatedSales(1, 1, pageable))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,16 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+
+ncp:
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png


### PR DESCRIPTION
## 📌 작업 내용
- [x] 관련 상품 목록 조회 API 구현
- [x] 테스트 코드 작성
- [x] 이미지 불러올 때 NCP 버킷에서 이미지를 불러오도록 설정

<br>

## 💡 필수확인

### 요청 URL
`GET` `/sale/related/{saleId}`

### 요청 파라미터
- `userId` : 로그인된 사용자 아이디 (추후 제거 예정)
- `saleId` : 관련 상품을 조회할 상품 아이디(PathVariable)

### 응답 데이터
```json
{
    "status": 200,
    "message": "관련상품 조회에 성공하였습니다.",
    "data": [
        {
            "saleId": 100000,
            "image": "https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/save_file?type=h&h=192&ttype=png",
            "saleTitle": "상추0100000",
            "price": 1145,
            "score": null,
            "reviewCount": 0,
            "like": false
        },
        {
            "saleId": 99999,
            "image": "https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/save_file?type=h&h=192&ttype=png",
            "saleTitle": "상추0099999",
            "price": 1212,
            "score": null,
            "reviewCount": 0,
            "like": false
        }
    ]
}
```

<br>

## 📆 작업기간
2025.4.16 ~ 2025.4.17
<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)