### PR TITLE
[FDORA-37] feat: 상품의 문의 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -10,6 +10,7 @@ public enum SuccessMessage {
     SEARCH_SALES_SUCCESS("상품 목록 조회에 성공하였습니다."),
     GET_SALE_DETAIL_SUCCESS("상품 상세 조회에 성공하였습니다."),
     SEARCH_QUESTION_SUCCESS("문의 목록 조회에 성공하였습니다."),
+    SEARCH_REVIEWS_SUCCESS("리뷰 목록 조회에 성공하였습니다."),
     GET_RELATED_SALES_SUCCESS("관련 상품 목록 조회에 성공하였습니다.");
 
     private final String message;

--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum SuccessMessage {
     SEARCH_ORDER_SUCCESS("주문 목록 조회에 성공하였습니다."),
     SEARCH_SALES_SUCCESS("상품 목록 조회에 성공하였습니다."),
-    GET_SALE_DETAIL_SUCCESS("상품 상세 조회에 성공하였습니다.");
+    GET_SALE_DETAIL_SUCCESS("상품 상세 조회에 성공하였습니다."),
+    GET_RELATED_SALES_SUCCESS("관련 상품 목록 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
@@ -5,7 +5,7 @@ import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTI
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import com.farmdora.farmdora.opinion.service.OpinionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -24,7 +24,7 @@ public class OpinionController {
 
     @GetMapping
     public ResponseEntity<?> searchQuestions(Integer sellerId,
-                                             QuestionSearchRequestDto searchCondition,
+                                             OpinionSearchRequestDto searchCondition,
                                              @PageableDefault Pageable pageable) {
         PageResponseDto<QuestionResponseDto> questions = opinionService.searchQuestions(sellerId, searchCondition, pageable);
         return ResponseEntity.ok()

--- a/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
@@ -1,12 +1,12 @@
-package com.farmdora.farmdora.question.controller;
+package com.farmdora.farmdora.opinion.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionSearchRequestDto;
-import com.farmdora.farmdora.question.service.QuestionService;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.service.OpinionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -19,14 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/my/seller/order/inquiry")
 @RequiredArgsConstructor
-public class QuestionController {
-    private final QuestionService questionService;
+public class OpinionController {
+    private final OpinionService opinionService;
 
     @GetMapping
     public ResponseEntity<?> searchQuestions(Integer sellerId,
                                              QuestionSearchRequestDto searchCondition,
                                              @PageableDefault Pageable pageable) {
-        PageResponseDto<QuestionResponseDto> questions = questionService.searchQuestions(sellerId, searchCondition, pageable);
+        PageResponseDto<QuestionResponseDto> questions = opinionService.searchQuestions(sellerId, searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_QUESTION_SUCCESS.getMessage(), questions));
     }

--- a/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
@@ -1,13 +1,16 @@
 package com.farmdora.farmdora.opinion.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
 import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
 import com.farmdora.farmdora.opinion.service.OpinionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -16,18 +19,27 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
-@RequestMapping("/my/seller/order/inquiry")
+@RequestMapping("/my/seller/order")
 @RequiredArgsConstructor
 public class OpinionController {
     private final OpinionService opinionService;
 
-    @GetMapping
+    @GetMapping("/inquiry")
     public ResponseEntity<?> searchQuestions(Integer sellerId,
                                              OpinionSearchRequestDto searchCondition,
                                              @PageableDefault Pageable pageable) {
         PageResponseDto<QuestionResponseDto> questions = opinionService.searchQuestions(sellerId, searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_QUESTION_SUCCESS.getMessage(), questions));
+    }
+
+    @GetMapping("/review")
+    public ResponseEntity<?> searchReviews(OpinionSearchRequestDto searchCondition,
+                                           @PageableDefault Pageable pageable) {
+        PageResponseDto<ReviewResponseDto> reviews = opinionService.searchReviews(searchCondition, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_REVIEWS_SUCCESS.getMessage(), reviews));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/OpinionSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/OpinionSearchRequestDto.java
@@ -17,6 +17,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OpinionSearchRequestDto {
+    private Integer sellerId;  // TODO JWT 구현완료 후 제거 예정
     private SearchType searchType;
     private String keyword;
     private SearchPeriod searchPeriod;

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/OpinionSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/OpinionSearchRequestDto.java
@@ -16,7 +16,7 @@ import lombok.*;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class QuestionSearchRequestDto {
+public class OpinionSearchRequestDto {
     private SearchType searchType;
     private String keyword;
     private SearchPeriod searchPeriod;

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/ProcessType.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/ProcessType.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.dto;
+package com.farmdora.farmdora.opinion.dto;
 
 public enum ProcessType {
     WAIT, DONE

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/QuestionResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/QuestionResponseDto.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.dto;
+package com.farmdora.farmdora.opinion.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/QuestionSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/QuestionSearchRequestDto.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.dto;
+package com.farmdora.farmdora.opinion.dto;
 
 import com.farmdora.farmdora.order.dto.SearchPeriod;
 import com.farmdora.farmdora.order.dto.SearchType;

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/ReviewResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/ReviewResponseDto.java
@@ -1,0 +1,34 @@
+package com.farmdora.farmdora.opinion.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+public class ReviewResponseDto {
+    private Integer reviewId;
+    private String saleTitle;
+    private String reviewContent;
+    private String writer;
+    private LocalDateTime createdDate;
+    private byte score;
+
+    @QueryProjection
+    public ReviewResponseDto(Integer reviewId,
+                             String saleTitle,
+                             String reviewContent,
+                             String writer,
+                             LocalDateTime createdDate,
+                             byte score) {
+        this.reviewId = reviewId;
+        this.saleTitle = saleTitle;
+        this.reviewContent = reviewContent;
+        this.writer = writer;
+        this.createdDate = createdDate;
+        this.score = score;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepository.java
@@ -1,10 +1,10 @@
 package com.farmdora.farmdora.opinion.repository;
 
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomQuestionRepository {
-    Page<QuestionResponseDto> searchQuestions(Integer sellerId, QuestionSearchRequestDto searchCondition, Pageable pageable);
+    Page<QuestionResponseDto> searchQuestions(Integer sellerId, OpinionSearchRequestDto searchCondition, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepository.java
@@ -1,7 +1,7 @@
-package com.farmdora.farmdora.question.repository;
+package com.farmdora.farmdora.opinion.repository;
 
-import com.farmdora.farmdora.question.dto.QuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/CustomReviewRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/CustomReviewRepository.java
@@ -1,0 +1,10 @@
+package com.farmdora.farmdora.opinion.repository;
+
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomReviewRepository {
+    Page<ReviewResponseDto> searchReviews(OpinionSearchRequestDto searchCondition, Pageable pageable);
+}

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/QuestionRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/QuestionRepository.java
@@ -1,7 +1,18 @@
 package com.farmdora.farmdora.opinion.repository;
 
 import com.farmdora.farmdora.entity.Question;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface QuestionRepository extends JpaRepository<Question, Integer>, CustomQuestionRepository {
+
+    @Query("SELECT new com.farmdora.farmdora.sale.dto.QuestionResponseDto(q.id, q.title, u.name, q.isProcess, q.createdDate) "
+            + "FROM Question q JOIN q.user u "
+            + "WHERE q.sale = :sale")
+    Page<QuestionResponseDto> findQuestionsBySaleId(@Param("sale")Sale sale, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/QuestionRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/QuestionRepository.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.repository;
+package com.farmdora.farmdora.opinion.repository;
 
 import com.farmdora.farmdora.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/ReviewRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.farmdora.farmdora.opinion.repository;
+
+import com.farmdora.farmdora.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Integer>, CustomReviewRepository {
+}

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/ReviewRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/ReviewRepository.java
@@ -1,7 +1,10 @@
 package com.farmdora.farmdora.opinion.repository;
 
 import com.farmdora.farmdora.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Integer>, CustomReviewRepository {
+    Page<Review> findAllBySaleId(Integer saleId, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
@@ -10,7 +10,7 @@ import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.opinion.dto.ProcessType;
 import com.farmdora.farmdora.opinion.dto.QQuestionResponseDto;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import com.farmdora.farmdora.opinion.repository.CustomQuestionRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -34,7 +34,7 @@ public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
     }
 
     @Override
-    public Page<QuestionResponseDto> searchQuestions(Integer sellerId, QuestionSearchRequestDto searchCondition, Pageable pageable) {
+    public Page<QuestionResponseDto> searchQuestions(Integer sellerId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
         List<QuestionResponseDto> questions = queryFactory
                 .select(new QQuestionResponseDto(
                         question.id,

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.repository.impl;
+package com.farmdora.farmdora.opinion.repository.impl;
 
 import static com.farmdora.farmdora.entity.QQuestion.question;
 import static com.farmdora.farmdora.entity.QSale.sale;
@@ -7,11 +7,11 @@ import static com.farmdora.farmdora.entity.QUser.user;
 import com.farmdora.farmdora.order.dto.SearchPeriod;
 import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.question.dto.ProcessType;
-import com.farmdora.farmdora.question.dto.QQuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionSearchRequestDto;
-import com.farmdora.farmdora.question.repository.CustomQuestionRepository;
+import com.farmdora.farmdora.opinion.dto.ProcessType;
+import com.farmdora.farmdora.opinion.dto.QQuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.repository.CustomQuestionRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomReviewRepositoryImpl.java
@@ -1,0 +1,127 @@
+package com.farmdora.farmdora.opinion.repository.impl;
+
+import static com.farmdora.farmdora.entity.QOrder.order;
+import static com.farmdora.farmdora.entity.QReview.review;
+import static com.farmdora.farmdora.entity.QSale.sale;
+import static com.farmdora.farmdora.entity.QUser.user;
+
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.QReviewResponseDto;
+import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
+import com.farmdora.farmdora.opinion.repository.CustomReviewRepository;
+import com.farmdora.farmdora.order.dto.SearchPeriod;
+import com.farmdora.farmdora.order.dto.SearchType;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@Slf4j
+public class CustomReviewRepositoryImpl implements CustomReviewRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CustomReviewRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<ReviewResponseDto> searchReviews(OpinionSearchRequestDto searchCondition, Pageable pageable) {
+        List<ReviewResponseDto> reviews = queryFactory
+                .select(
+                        new QReviewResponseDto(review.id, sale.title, review.content, user.name, review.createdDate, review.score)
+                )
+                .from(sale)
+                .join(review).on(review.sale.eq(sale))
+                .join(order).on(review.order.eq(order))
+                .join(user).on(order.user.eq(user))
+                .where(
+                        sale.seller.id.eq(searchCondition.getSellerId()),
+                        keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
+                        dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(),
+                                searchCondition.getSearchPeriod())
+                )
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .orderBy(reviewsOrderBy(searchCondition.getSort()), reviewIdOrderBy(searchCondition.getSort()))
+                .fetch();
+
+        log.info("리뷰 : {}", reviews);
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(review.id.countDistinct())
+                .from(sale)
+                .join(review).on(review.sale.eq(sale))
+                .join(order).on(review.order.eq(order))
+                .join(user).on(order.user.eq(user))
+                .where(
+                        sale.seller.id.eq(searchCondition.getSellerId()),
+                        keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
+                        dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(), searchCondition.getSearchPeriod())
+                );
+
+        log.info("리뷰 개수: {}", countQuery.fetchOne());
+
+        return PageableExecutionUtils.getPage(reviews, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression keywordContains(SearchType searchType, String keyword) {
+        if (searchType != null && keyword != null) {
+            if (searchType.equals(SearchType.PRODUCT)) {
+                return sale.title.contains(keyword);
+            } else if (searchType.equals(SearchType.BUYER)){
+                return review.order.user.name.contains(keyword);
+            }
+        }
+        return null;
+    }
+
+    private BooleanExpression dateBetween(LocalDateTime startDate, LocalDateTime endDate, SearchPeriod searchPeriod) {
+        if (startDate != null && endDate != null) {
+            return review.createdDate.between(startDate, endDate);
+        } else if (searchPeriod != null) {
+            return periodBetween(searchPeriod);
+        }
+        return null;
+    }
+
+    private BooleanExpression periodBetween(SearchPeriod searchPeriod) {
+        return switch (searchPeriod) {
+            case TODAY -> review.createdDate.between(LocalDateTime.now().minusDays(1), LocalDateTime.now());
+            case WEEK -> review.createdDate.between(LocalDateTime.now().minusWeeks(1), LocalDateTime.now());
+            case ONE_MONTH -> review.createdDate.between(LocalDateTime.now().minusMonths(1), LocalDateTime.now());
+            case THREE_MONTHS -> review.createdDate.between(LocalDateTime.now().minusMonths(3), LocalDateTime.now());
+            default -> null;
+        };
+    }
+
+    private OrderSpecifier<?> reviewsOrderBy(Sort sort) {
+        if (sort != null) {
+            return switch (sort) {
+                case LATEST -> review.createdDate.desc();
+                case OLDEST -> review.createdDate.asc();
+                default -> null;
+            };
+        }
+        return review.createdDate.desc();
+    }
+
+    private OrderSpecifier<?> reviewIdOrderBy(Sort sort) {
+        if (sort != null) {
+            return switch (sort) {
+                case LATEST -> review.id.desc();
+                case OLDEST -> review.id.asc();
+                default -> null;
+            };
+        }
+        return review.id.desc();
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
@@ -1,9 +1,9 @@
-package com.farmdora.farmdora.question.service;
+package com.farmdora.farmdora.opinion.service;
 
 import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionSearchRequestDto;
-import com.farmdora.farmdora.question.repository.QuestionRepository;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class QuestionService {
+public class OpinionService {
     private final QuestionRepository questionRepository;
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
@@ -3,7 +3,9 @@ package com.farmdora.farmdora.opinion.service;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
 import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
 import com.farmdora.farmdora.opinion.repository.QuestionRepository;
+import com.farmdora.farmdora.opinion.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,10 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OpinionService {
     private final QuestionRepository questionRepository;
+    private final ReviewRepository reviewRepository;
 
     @Transactional(readOnly = true)
     public PageResponseDto<QuestionResponseDto> searchQuestions(Integer sellerId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
         Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
         return new PageResponseDto<>(questions.getContent(), questions);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<ReviewResponseDto> searchReviews(OpinionSearchRequestDto searchCondition, Pageable pageable) {
+        Page<ReviewResponseDto> reviews = reviewRepository.searchReviews(searchCondition, pageable);
+        return new PageResponseDto<>(reviews.getContent(), reviews);
     }
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
@@ -2,7 +2,7 @@ package com.farmdora.farmdora.opinion.service;
 
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,7 +17,7 @@ public class OpinionService {
     private final QuestionRepository questionRepository;
 
     @Transactional(readOnly = true)
-    public PageResponseDto<QuestionResponseDto> searchQuestions(Integer sellerId, QuestionSearchRequestDto searchCondition, Pageable pageable) {
+    public PageResponseDto<QuestionResponseDto> searchQuestions(Integer sellerId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
         Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
         return new PageResponseDto<>(questions.getContent(), questions);
     }

--- a/src/main/java/com/farmdora/farmdora/order/repository/impl/CustomOrderRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/order/repository/impl/CustomOrderRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.order.repository;
+package com.farmdora.farmdora.order.repository.impl;
 
 import static com.farmdora.farmdora.entity.QOption.option;
 import static com.farmdora.farmdora.entity.QOrder.order;
@@ -16,6 +16,7 @@ import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.querydsl.OrderDto;
 import com.farmdora.farmdora.order.dto.querydsl.QOrderDetailDto;
 import com.farmdora.farmdora.order.dto.querydsl.QOrderDto;
+import com.farmdora.farmdora.order.repository.CustomOrderRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -2,8 +2,11 @@ package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.service.SaleService;
@@ -40,5 +43,14 @@ public class SaleController {
         List<SaleRelatedDto> relatedSales = saleService.getRelatedSales(userId, saleId, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_RELATED_SALES_SUCCESS.getMessage(), relatedSales));
+    }
+
+    @GetMapping("/review/{saleId}")
+    public ResponseEntity<?> getSaleReviews(@PathVariable("saleId") Integer saleId,
+                                            @PageableDefault Pageable pageable) {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        PageResponseDto<ReviewDetailDto> reviews = saleService.getSaleReviews(saleId, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_REVIEWS_SUCCESS.getMessage(), reviews));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -1,23 +1,20 @@
 package com.farmdora.farmdora.sale.controller;
 
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
-import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
-import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.service.SaleService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,5 +30,15 @@ public class SaleController {
         SaleDetailDto saleDetail = saleService.getSaleDetail(userId, saleId);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALE_DETAIL_SUCCESS.getMessage(), saleDetail));
+    }
+
+    @GetMapping("/related/{saleId}")
+    public ResponseEntity<?> getRelatedSales(Integer userId,
+                                             @PathVariable("saleId") Integer saleId,
+                                             @PageableDefault Pageable pageable) {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        List<SaleRelatedDto> relatedSales = saleService.getRelatedSales(userId, saleId, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, GET_RELATED_SALES_SUCCESS.getMessage(), relatedSales));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -2,10 +2,12 @@ package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
@@ -52,5 +54,13 @@ public class SaleController {
         PageResponseDto<ReviewDetailDto> reviews = saleService.getSaleReviews(saleId, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_REVIEWS_SUCCESS.getMessage(), reviews));
+    }
+
+    @GetMapping("/question/{saleId}")
+    public ResponseEntity<?> getSaleQuestions(@PathVariable("saleId") Integer saleId,
+                                              @PageableDefault Pageable pageable) {
+        PageResponseDto<QuestionResponseDto> questions = saleService.getSaleQuestions(saleId, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_QUESTION_SUCCESS.getMessage(), questions));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
@@ -1,11 +1,9 @@
 package com.farmdora.farmdora.sale.controller;
 
-import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.service.SaleService;
@@ -15,23 +13,35 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
-@RequestMapping("/sale")
+@RequestMapping("/my/seller/sale")
 @RequiredArgsConstructor
-public class SaleController {
+public class SellerSaleController {
     private final SaleService saleService;
 
-    @GetMapping("/{saleId}")
-    public ResponseEntity<?> getSaleDetail(Integer userId, @PathVariable("saleId") Integer saleId) {
+    @PostMapping("/search")
+    public ResponseEntity<?> searchWithJson(@RequestBody SaleSearchRequestDto searchCondition) {
         // TODO 스프링 시큐리티 구현 후 userId 가져오기
-        SaleDetailDto saleDetail = saleService.getSaleDetail(userId, saleId);
+        log.info("상품 목록 검색: {}", searchCondition);
+        Pageable pageable = searchCondition.toPageable();
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(searchCondition.getSellerId(), searchCondition, pageable);
         return ResponseEntity.ok()
-                .body(new HttpResponse(HttpStatus.OK, GET_SALE_DETAIL_SUCCESS.getMessage(), saleDetail));
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<?> searchWithParams() {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder().build();
+        Pageable pageable = searchCondition.toPageable();
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(1, searchCondition, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
@@ -7,6 +7,7 @@ import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.service.SaleService;
+import com.farmdora.farmdora.sale.service.SellerSaleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/my/seller/sale")
 @RequiredArgsConstructor
 public class SellerSaleController {
-    private final SaleService saleService;
+    private final SellerSaleService saleService;
 
     @PostMapping("/search")
     public ResponseEntity<?> searchWithJson(@RequestBody SaleSearchRequestDto searchCondition) {

--- a/src/main/java/com/farmdora/farmdora/sale/dto/QuestionResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/QuestionResponseDto.java
@@ -1,0 +1,18 @@
+package com.farmdora.farmdora.sale.dto;
+
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionResponseDto {
+    private Integer id;
+    private String title;
+    private String writer;
+    private boolean isProcess;
+    private LocalDateTime createdDate;
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/ReviewDetailDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/ReviewDetailDto.java
@@ -1,0 +1,29 @@
+package com.farmdora.farmdora.sale.dto;
+
+import com.farmdora.farmdora.entity.Review;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDetailDto {
+    private Integer reviewId;
+    private String writer;
+    private String content;
+    private Byte score;
+    private LocalDateTime createdDate;
+
+    public static ReviewDetailDto fromEntity(Review review) {
+        return ReviewDetailDto.builder()
+                .reviewId(review.getId())
+                .writer(review.getOrder().getUser().getName())
+                .content(review.getContent())
+                .score(review.getScore())
+                .createdDate(review.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedDto.java
@@ -1,0 +1,31 @@
+package com.farmdora.farmdora.sale.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleRelatedDto {
+    private Integer saleId;
+    private String image;
+    private String saleTitle;
+    private Integer price;
+    private Double score;
+    private Long reviewCount;
+    private boolean isLike;
+
+    public static SaleRelatedDto createSaleRelatedDto(SaleRelatedInfoDto saleInfo, String mainImage, boolean isLike) {
+        return SaleRelatedDto.builder()
+                .saleId(saleInfo.getSaleId())
+                .image(mainImage)
+                .saleTitle(saleInfo.getTitle())
+                .price(saleInfo.getPrice())
+                .score(saleInfo.getScore())
+                .reviewCount(saleInfo.getReviewCount())
+                .isLike(isLike)
+                .build();
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedInfoDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleRelatedInfoDto.java
@@ -1,0 +1,22 @@
+package com.farmdora.farmdora.sale.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleRelatedInfoDto {
+    private Integer saleId;
+    private String title;
+    private Integer price;
+    private Double score;
+    private Long reviewCount;
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleFileRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleFileRepository.java
@@ -3,8 +3,10 @@ package com.farmdora.farmdora.sale.repository;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SaleFileRepository extends JpaRepository<SaleFile, Integer> {
     List<SaleFile> findAllBySale(Sale sale);
+    Optional<SaleFile> findBySaleIdAndIsMainIsTrue(Integer saleId);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
@@ -1,7 +1,28 @@
 package com.farmdora.farmdora.sale.repository;
 
 import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleType;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SaleRepository extends JpaRepository<Sale, Integer>, CustomSaleRepository {
+
+    @Query("SELECT new com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto(s.id, s.title, MIN(o.price), AVG(r.score), COUNT(r)) " +
+            "FROM Sale s " +
+            "LEFT JOIN Review r ON r.sale = s " +
+            "LEFT JOIN Option o ON o.sale = s " +
+            "WHERE s.type = :type " +
+            "AND s.id <> :excludedId " +
+            "GROUP BY s.id, s.title " +
+            "ORDER BY s.id DESC")
+    List<SaleRelatedInfoDto> findTop10SalesWithReviewCountByTypeAndExcludedId(
+            @Param("type") SaleType type,
+            @Param("excludedId") Integer excludedId,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.sale.repository;
+package com.farmdora.farmdora.sale.repository.impl;
 
 import static com.farmdora.farmdora.entity.QOption.option;
 import static com.farmdora.farmdora.entity.QOrderOption.orderOption;
@@ -13,6 +13,7 @@ import com.farmdora.farmdora.sale.dto.querydsl.QSaleDto;
 import com.farmdora.farmdora.sale.dto.querydsl.QSaleOrderCountDto;
 import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
 import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.sale.repository.CustomSaleRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -3,8 +3,11 @@ package com.farmdora.farmdora.sale.service;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
+import com.farmdora.farmdora.opinion.repository.ReviewRepository;
+import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
@@ -37,6 +40,7 @@ public class SaleService {
     private final OptionRepository optionRepository;
     private final SaleFileRepository saleFileRepository;
     private final LikeRepository likeRepository;
+    private final ReviewRepository reviewRepository;
     private final SaleMapper saleMapper;
 
     @Value("${ncp.image.path}")
@@ -116,5 +120,15 @@ public class SaleService {
             mainImage = String.format("%s%s%s", imagePath, saleFile.get().getSaveFile(), type);
         }
         return mainImage;
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<ReviewDetailDto> getSaleReviews(Integer saleId, Pageable pageable) {
+        Page<Review> reviews = reviewRepository.findAllBySaleId(saleId, pageable);
+        List<ReviewDetailDto> reviewDetails = reviews.getContent()
+                .stream()
+                .map(ReviewDetailDto::fromEntity)
+                .toList();
+        return new PageResponseDto<>(reviewDetails, reviews);
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -6,6 +6,8 @@ import com.farmdora.farmdora.entity.Option;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
@@ -17,12 +19,16 @@ import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -32,6 +38,12 @@ public class SaleService {
     private final SaleFileRepository saleFileRepository;
     private final LikeRepository likeRepository;
     private final SaleMapper saleMapper;
+
+    @Value("${ncp.image.path}")
+    private String imagePath;
+
+    @Value("${ncp.image.type}")
+    private String type;
 
     @Transactional(readOnly = true)
     public PageResponseDto<SaleSearchResponseDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
@@ -73,5 +85,36 @@ public class SaleService {
         boolean exists = likeRepository.existsByUserIdAndSaleId(userId, saleId);
 
         return SaleDetailDto.createSaleDetail(sale, saleImages, options, exists);
+    }
+
+    @Transactional(readOnly = true)
+    public List<SaleRelatedDto> getRelatedSales(Integer userId, Integer saleId, Pageable pageable) {
+        Sale sale = saleRepository.findById(saleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sale", saleId));
+
+        List<SaleRelatedInfoDto> relatedSaleDetails = saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(sale.getType(), saleId, pageable);
+        List<SaleRelatedDto> relatedSales = getRelatedSalesMainImageAndIsLike(userId, relatedSaleDetails);
+
+        log.info("관련 상품 목록: {}", relatedSales);
+
+        return relatedSales;
+    }
+
+    private List<SaleRelatedDto> getRelatedSalesMainImageAndIsLike(Integer userId, List<SaleRelatedInfoDto> relatedSaleDetails) {
+        List<SaleRelatedDto> relatedSales = new ArrayList<>();
+        for (SaleRelatedInfoDto relatedSale : relatedSaleDetails) {
+            boolean isLike = likeRepository.existsByUserIdAndSaleId(userId, relatedSale.getSaleId());
+            Optional<SaleFile> saleFile = saleFileRepository.findBySaleIdAndIsMainIsTrue(relatedSale.getSaleId());
+            relatedSales.add(SaleRelatedDto.createSaleRelatedDto(relatedSale, getMainImage(saleFile), isLike));
+        }
+        return relatedSales;
+    }
+
+    private String getMainImage(Optional<SaleFile> saleFile) {
+        String mainImage = null;
+        if (saleFile.isPresent()) {
+            mainImage = String.format("%s%s%s", imagePath, saleFile.get().getSaveFile(), type);
+        }
+        return mainImage;
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -11,10 +11,6 @@ import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
 import com.farmdora.farmdora.sale.mapper.SaleMapper;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
@@ -48,32 +44,6 @@ public class SaleService {
 
     @Value("${ncp.image.type}")
     private String type;
-
-    @Transactional(readOnly = true)
-    public PageResponseDto<SaleSearchResponseDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
-        Page<SaleDto> salePage = saleRepository.searchSales(sellerId, searchCondition, pageable);
-        List<SaleDto> sales = salePage.getContent();
-        List<Integer> saleIds = getSaleIds(sales);
-        List<SaleOrderCountDto> orderCounts = getOrderCounts(saleIds);
-        List<SaleSearchResponseDto> saleSearchResponseDtos = saleMapper.mapToSaleSearchResponseDto(saleIds, sales, orderCounts);
-
-        return new PageResponseDto<>(saleSearchResponseDtos, salePage);
-    }
-
-    private List<SaleOrderCountDto> getOrderCounts(List<Integer> saleIds) {
-        List<SaleOrderCountDto> orderCounts = new ArrayList<>();
-        if (!saleIds.isEmpty()) {
-            orderCounts = saleRepository.searchSaleOrderCount(saleIds);
-        }
-        return orderCounts;
-    }
-
-    private List<Integer> getSaleIds(List<SaleDto> sales) {
-        return sales
-                .stream()
-                .map(SaleDto::getSaleId)
-                .toList();
-    }
 
     @Transactional(readOnly = true)
     public SaleDetailDto getSaleDetail(Integer userId, Integer saleId) {

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -6,12 +6,13 @@ import com.farmdora.farmdora.entity.Option;
 import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
+import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import com.farmdora.farmdora.opinion.repository.ReviewRepository;
+import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
-import com.farmdora.farmdora.sale.mapper.SaleMapper;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
@@ -37,7 +38,7 @@ public class SaleService {
     private final SaleFileRepository saleFileRepository;
     private final LikeRepository likeRepository;
     private final ReviewRepository reviewRepository;
-    private final SaleMapper saleMapper;
+    private final QuestionRepository questionRepository;
 
     @Value("${ncp.image.path}")
     private String imagePath;
@@ -100,5 +101,14 @@ public class SaleService {
                 .map(ReviewDetailDto::fromEntity)
                 .toList();
         return new PageResponseDto<>(reviewDetails, reviews);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<QuestionResponseDto> getSaleQuestions(Integer saleId, Pageable pageable) {
+        Sale sale = saleRepository.findById(saleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sale", saleId));
+
+        Page<QuestionResponseDto> questions = questionRepository.findQuestionsBySaleId(sale, pageable);
+        return new PageResponseDto<>(questions.getContent(), questions);
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/service/SellerSaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SellerSaleService.java
@@ -1,0 +1,50 @@
+package com.farmdora.farmdora.sale.service;
+
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.sale.mapper.SaleMapper;
+import com.farmdora.farmdora.sale.repository.SaleRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SellerSaleService {
+
+    private final SaleRepository saleRepository;
+    private final SaleMapper saleMapper;
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<SaleSearchResponseDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
+        Page<SaleDto> salePage = saleRepository.searchSales(sellerId, searchCondition, pageable);
+        List<SaleDto> sales = salePage.getContent();
+        List<Integer> saleIds = getSaleIds(sales);
+        List<SaleOrderCountDto> orderCounts = getOrderCounts(saleIds);
+        List<SaleSearchResponseDto> saleSearchResponseDtos = saleMapper.mapToSaleSearchResponseDto(saleIds, sales, orderCounts);
+
+        return new PageResponseDto<>(saleSearchResponseDtos, salePage);
+    }
+
+    private List<SaleOrderCountDto> getOrderCounts(List<Integer> saleIds) {
+        List<SaleOrderCountDto> orderCounts = new ArrayList<>();
+        if (!saleIds.isEmpty()) {
+            orderCounts = saleRepository.searchSaleOrderCount(saleIds);
+        }
+        return orderCounts;
+    }
+
+    private List<Integer> getSaleIds(List<SaleDto> sales) {
+        return sales
+                .stream()
+                .map(SaleDto::getSaleId)
+                .toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+ncp:
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png

--- a/src/test/java/com/farmdora/farmdora/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/ControllerTest.java
@@ -7,6 +7,7 @@ import com.farmdora.farmdora.opinion.service.OpinionService;
 import com.farmdora.farmdora.sale.controller.SaleController;
 import com.farmdora.farmdora.sale.controller.SellerSaleController;
 import com.farmdora.farmdora.sale.service.SaleService;
+import com.farmdora.farmdora.sale.service.SellerSaleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -29,6 +30,9 @@ public abstract class ControllerTest {
 
     @MockitoBean
     protected SaleService saleService;
+
+    @MockitoBean
+    protected SellerSaleService sellerSaleService;
 
     @MockitoBean
     protected OpinionService opinionService;

--- a/src/test/java/com/farmdora/farmdora/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/ControllerTest.java
@@ -3,6 +3,7 @@ package com.farmdora.farmdora;
 import com.farmdora.farmdora.order.controller.OrderController;
 import com.farmdora.farmdora.order.service.OrderService;
 import com.farmdora.farmdora.sale.controller.SaleController;
+import com.farmdora.farmdora.sale.controller.SellerSaleController;
 import com.farmdora.farmdora.sale.service.SaleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = {
         OrderController.class,
+        SellerSaleController.class,
         SaleController.class
 })
 public abstract class ControllerTest {

--- a/src/test/java/com/farmdora/farmdora/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/ControllerTest.java
@@ -2,8 +2,8 @@ package com.farmdora.farmdora;
 
 import com.farmdora.farmdora.order.controller.OrderController;
 import com.farmdora.farmdora.order.service.OrderService;
-import com.farmdora.farmdora.question.controller.QuestionController;
-import com.farmdora.farmdora.question.service.QuestionService;
+import com.farmdora.farmdora.opinion.controller.OpinionController;
+import com.farmdora.farmdora.opinion.service.OpinionService;
 import com.farmdora.farmdora.sale.controller.SaleController;
 import com.farmdora.farmdora.sale.controller.SellerSaleController;
 import com.farmdora.farmdora.sale.service.SaleService;
@@ -15,7 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = {
         OrderController.class,
         SaleController.class,
-        QuestionController.class,
+        OpinionController.class,
         SellerSaleController.class,
         SaleController.class
 })
@@ -31,5 +31,5 @@ public abstract class ControllerTest {
     protected SaleService saleService;
 
     @MockitoBean
-    protected QuestionService questionService;
+    protected OpinionService opinionService;
 }

--- a/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
@@ -12,7 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +49,7 @@ class OpinionControllerTest extends ControllerTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<QuestionResponseDto> questionPage = new PageImpl<>(questions, pageable, 2);
         PageResponseDto<QuestionResponseDto> result = new PageResponseDto<>(questions, questionPage);
-        when(opinionService.searchQuestions(anyInt(), any(QuestionSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+        when(opinionService.searchQuestions(anyInt(), any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
 
         // when
         // then

--- a/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.controller;
+package com.farmdora.farmdora.opinion.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -11,8 +11,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +22,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-class QuestionControllerTest extends ControllerTest {
+class OpinionControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("문의 목록 검색 API 테스트")
@@ -49,7 +49,7 @@ class QuestionControllerTest extends ControllerTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<QuestionResponseDto> questionPage = new PageImpl<>(questions, pageable, 2);
         PageResponseDto<QuestionResponseDto> result = new PageResponseDto<>(questions, questionPage);
-        when(questionService.searchQuestions(anyInt(), any(QuestionSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+        when(opinionService.searchQuestions(anyInt(), any(QuestionSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
 
         // when
         // then

--- a/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdora.opinion.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -13,6 +14,7 @@ import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
 import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -64,6 +66,46 @@ class OpinionControllerTest extends ControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status", equalTo(200)))
                 .andExpect(jsonPath("$.message", equalTo(SEARCH_QUESTION_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.data.contents.size()", equalTo(2)));
+    }
+
+    @Test
+    @DisplayName("리뷰 목록 검색 API 테스트")
+    void testSearchReviews() throws Exception {
+        // given
+        List<ReviewResponseDto> reviews = List.of(
+                ReviewResponseDto.builder()
+                        .saleTitle("sale")
+                        .reviewContent("review1")
+                        .writer("user1")
+                        .createdDate(LocalDateTime.now())
+                        .score((byte) 4)
+                        .build(),
+                ReviewResponseDto.builder()
+                        .saleTitle("sale")
+                        .reviewContent("review2")
+                        .writer("user2")
+                        .createdDate(LocalDateTime.now())
+                        .score((byte) 3)
+                        .build()
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ReviewResponseDto> reviewPage = new PageImpl<>(reviews, pageable, 2);
+        PageResponseDto<ReviewResponseDto> result = new PageResponseDto<>(reviews, reviewPage);
+        when(opinionService.searchReviews(any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+        // when
+        // then
+        mvc.perform(get("/my/seller/order/review")
+                        .param("sellerId", "1")
+                        .param("searchType", "PRODUCT")
+                        .param("keyword", "상추")
+                        .param("searchPeriod", "TODAY")
+                        .param("sort", "LATEST")
+                        .param("page", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(SEARCH_REVIEWS_SUCCESS.getMessage())))
                 .andExpect(jsonPath("$.data.contents.size()", equalTo(2)));
     }
 }

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepositoryTest.java
@@ -1,0 +1,149 @@
+package com.farmdora.farmdora.opinion.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Question;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.order.dto.SearchPeriod;
+import com.farmdora.farmdora.order.dto.SearchType;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.opinion.dto.ProcessType;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@Import(AuditConfig.class)
+class CustomQuestionRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    private Seller seller;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .phoneNum("010-1234-5678")
+                .name("user")
+                .build();
+        em.persist(user);
+
+        seller = Seller.builder()
+                .name("seller")
+                .build();
+        em.persist(seller);
+
+        for (int i = 1; i <= 10; i++) {
+            Sale sale = Sale.builder()
+                    .title("상추" + i)
+                    .seller(seller)
+                    .build();
+            em.persist(sale);
+
+            Question question = Question.builder()
+                    .user(user)
+                    .sale(sale)
+                    .title("title" + i)
+                    .content("content" + i)
+                    .isProcess(false)
+                    .isBlind(false)
+                    .build();
+            em.persist(question);
+        }
+    }
+
+    @Test
+    @DisplayName("상품명으로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
+    void testSearchQuestions() {
+        // given
+        Integer sellerId = seller.getId();
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
+                .searchType(SearchType.PRODUCT)
+                .keyword("상추")
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .processTypes(List.of(ProcessType.WAIT))
+                .sort(Sort.OLDEST)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
+
+        // then
+        System.out.println(questions.getContent());
+        List<QuestionResponseDto> questionResult = questions.getContent();
+        assertThat(questionResult.size()).isEqualTo(10);
+        assertThat(questions.getNumber()).isEqualTo(0);
+        assertThat(questions.getTotalElements()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("작성자명으로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
+    void testSearchQuestionsByWriter() {
+        // given
+        Integer sellerId = seller.getId();
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
+                .searchType(SearchType.BUYER)
+                .keyword("user")
+                .startDate(LocalDateTime.now().minusDays(1))
+                .endDate(LocalDateTime.now().plusDays(1))
+                .processTypes(List.of(ProcessType.WAIT))
+                .sort(Sort.OLDEST)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
+
+        // then
+        System.out.println(questions.getContent());
+        List<QuestionResponseDto> questionResult = questions.getContent();
+        assertThat(questionResult.size()).isEqualTo(10);
+        assertThat(questions.getNumber()).isEqualTo(0);
+        assertThat(questions.getTotalElements()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("SearchPeriod로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
+    void testSearchQuestionsBySearchPeriod() {
+        // given
+        Integer sellerId = seller.getId();
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
+                .searchType(SearchType.BUYER)
+                .keyword("user")
+                .searchPeriod(SearchPeriod.TODAY)
+                .processTypes(List.of(ProcessType.WAIT))
+                .sort(Sort.OLDEST)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
+
+        // then
+        System.out.println(questions.getContent());
+        List<QuestionResponseDto> questionResult = questions.getContent();
+        assertThat(questionResult.size()).isEqualTo(10);
+        assertThat(questions.getNumber()).isEqualTo(0);
+        assertThat(questions.getTotalElements()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/QuestionRepositoryTest.java
@@ -12,7 +12,7 @@ import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.opinion.dto.ProcessType;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,7 +75,7 @@ class QuestionRepositoryTest {
     void testSearchQuestions() {
         // given
         Integer sellerId = seller.getId();
-        QuestionSearchRequestDto searchCondition = QuestionSearchRequestDto.builder()
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
                 .searchType(SearchType.PRODUCT)
                 .keyword("상추")
                 .startDate(LocalDateTime.now().minusDays(1))
@@ -101,7 +101,7 @@ class QuestionRepositoryTest {
     void testSearchQuestionsByWriter() {
         // given
         Integer sellerId = seller.getId();
-        QuestionSearchRequestDto searchCondition = QuestionSearchRequestDto.builder()
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
                 .searchType(SearchType.BUYER)
                 .keyword("user")
                 .startDate(LocalDateTime.now().minusDays(1))
@@ -127,7 +127,7 @@ class QuestionRepositoryTest {
     void testSearchQuestionsBySearchPeriod() {
         // given
         Integer sellerId = seller.getId();
-        QuestionSearchRequestDto searchCondition = QuestionSearchRequestDto.builder()
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
                 .searchType(SearchType.BUYER)
                 .keyword("user")
                 .searchPeriod(SearchPeriod.TODAY)

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/QuestionRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.repository;
+package com.farmdora.farmdora.opinion.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,9 +10,9 @@ import com.farmdora.farmdora.entity.User;
 import com.farmdora.farmdora.order.dto.SearchPeriod;
 import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.question.dto.ProcessType;
-import com.farmdora.farmdora.question.dto.QuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.ProcessType;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/QuestionRepositoryTest.java
@@ -2,32 +2,20 @@ package com.farmdora.farmdora.opinion.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.farmdora.farmdora.config.AuditConfig;
 import com.farmdora.farmdora.entity.Question;
 import com.farmdora.farmdora.entity.Sale;
-import com.farmdora.farmdora.entity.Seller;
 import com.farmdora.farmdora.entity.User;
-import com.farmdora.farmdora.order.dto.SearchPeriod;
-import com.farmdora.farmdora.order.dto.SearchType;
-import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.opinion.dto.ProcessType;
-import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
-import java.time.LocalDateTime;
-import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
+import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @DataJpaTest
-@Import(AuditConfig.class)
 class QuestionRepositoryTest {
 
     @Autowired
@@ -36,114 +24,37 @@ class QuestionRepositoryTest {
     @Autowired
     private QuestionRepository questionRepository;
 
-    private Seller seller;
+    @Test
+    @DisplayName("findQuestionsBySaleId() 쿼리메서드 테스트")
+    void testFindQuestionsBySaleId() {
+        // given
+        Sale sale = new Sale();
+        em.persist(sale);
 
-    @BeforeEach
-    void setUp() {
-        User user = User.builder()
-                .phoneNum("010-1234-5678")
-                .name("user")
-                .build();
+        User user = new User();
         em.persist(user);
 
-        seller = Seller.builder()
-                .name("seller")
-                .build();
-        em.persist(seller);
-
         for (int i = 1; i <= 10; i++) {
-            Sale sale = Sale.builder()
-                    .title("상추" + i)
-                    .seller(seller)
-                    .build();
-            em.persist(sale);
-
             Question question = Question.builder()
-                    .user(user)
-                    .sale(sale)
-                    .title("title" + i)
+                    .title("question" + i)
                     .content("content" + i)
-                    .isProcess(false)
                     .isBlind(false)
+                    .isProcess(true)
+                    .answer("answer")
+                    .sale(sale)
+                    .user(user)
                     .build();
             em.persist(question);
         }
-    }
 
-    @Test
-    @DisplayName("상품명으로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
-    void testSearchQuestions() {
-        // given
-        Integer sellerId = seller.getId();
-        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
-                .searchType(SearchType.PRODUCT)
-                .keyword("상추")
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
-                .processTypes(List.of(ProcessType.WAIT))
-                .sort(Sort.OLDEST)
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
+        em.flush();
+        em.clear();
 
         // when
-        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
-
-        // then
-        System.out.println(questions.getContent());
-        List<QuestionResponseDto> questionResult = questions.getContent();
-        assertThat(questionResult.size()).isEqualTo(10);
-        assertThat(questions.getNumber()).isEqualTo(0);
-        assertThat(questions.getTotalElements()).isEqualTo(10);
-    }
-
-    @Test
-    @DisplayName("작성자명으로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
-    void testSearchQuestionsByWriter() {
-        // given
-        Integer sellerId = seller.getId();
-        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
-                .searchType(SearchType.BUYER)
-                .keyword("user")
-                .startDate(LocalDateTime.now().minusDays(1))
-                .endDate(LocalDateTime.now().plusDays(1))
-                .processTypes(List.of(ProcessType.WAIT))
-                .sort(Sort.OLDEST)
-                .build();
         Pageable pageable = PageRequest.of(0, 10);
-
-        // when
-        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
+        Page<QuestionResponseDto> questions = questionRepository.findQuestionsBySaleId(sale, pageable);
 
         // then
-        System.out.println(questions.getContent());
-        List<QuestionResponseDto> questionResult = questions.getContent();
-        assertThat(questionResult.size()).isEqualTo(10);
-        assertThat(questions.getNumber()).isEqualTo(0);
-        assertThat(questions.getTotalElements()).isEqualTo(10);
-    }
-
-    @Test
-    @DisplayName("SearchPeriod로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
-    void testSearchQuestionsBySearchPeriod() {
-        // given
-        Integer sellerId = seller.getId();
-        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
-                .searchType(SearchType.BUYER)
-                .keyword("user")
-                .searchPeriod(SearchPeriod.TODAY)
-                .processTypes(List.of(ProcessType.WAIT))
-                .sort(Sort.OLDEST)
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
-
-        // when
-        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
-
-        // then
-        System.out.println(questions.getContent());
-        List<QuestionResponseDto> questionResult = questions.getContent();
-        assertThat(questionResult.size()).isEqualTo(10);
-        assertThat(questions.getNumber()).isEqualTo(0);
-        assertThat(questions.getTotalElements()).isEqualTo(10);
+        assertThat(questions.getContent().size()).isEqualTo(10);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/ReviewRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.farmdora.farmdora.opinion.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.farmdora.farmdora.config.AuditConfig;
 import com.farmdora.farmdora.entity.Order;
 import com.farmdora.farmdora.entity.Review;
@@ -73,5 +75,37 @@ public class ReviewRepositoryTest {
 
         // then
         System.out.println(result.getContent());
+    }
+
+    @Test
+    @DisplayName("findAllBySaleId() 쿼리메서드 테스트")
+    void testFindAllBySaleId() {
+        // given
+        Sale sale = new Sale();
+        em.persist(sale);
+
+        Review review1 = Review.builder()
+                .sale(sale)
+                .content("review1")
+                .score((byte) 2)
+                .build();
+        Review review2 = Review.builder()
+                .sale(sale)
+                .content("review2")
+                .score((byte) 3)
+                .build();
+        em.persist(review1);
+        em.persist(review2);
+
+        em.flush();
+        em.clear();
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Review> reviews = reviewRepository.findAllBySaleId(sale.getId(), pageable);
+
+        // then
+        assertThat(reviews.getContent().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/ReviewRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.farmdora.farmdora.opinion.repository;
+
+import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Order;
+import com.farmdora.farmdora.entity.Review;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
+import com.farmdora.farmdora.order.dto.SearchPeriod;
+import com.farmdora.farmdora.order.dto.SearchType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+@Import(AuditConfig.class)
+public class ReviewRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("판매자의 리뷰 목록 검색 QueryDsl 테스트")
+    void testSearchReviews() {
+        // given
+        Seller seller = new Seller();
+        em.persist(seller);
+
+        Sale sale = Sale.builder()
+                .title("sale")
+                .build();
+        em.persist(sale);
+
+        User user = User.builder()
+                .name("user")
+                .build();
+        em.persist(user);
+
+        Order order = Order.builder()
+                .user(user)
+                .build();
+        em.persist(order);
+
+        for (int i = 1; i <= 10; i++) {
+            Review review = Review.builder()
+                    .content("review" + i)
+                    .score((byte) (i % 5))
+                    .order(order)
+                    .build();
+            em.persist(review);
+        }
+
+        // when
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
+                .sellerId(seller.getId())
+                .searchType(SearchType.PRODUCT)
+                .keyword("sale")
+                .searchPeriod(SearchPeriod.WEEK)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ReviewResponseDto> result = reviewRepository.searchReviews(searchCondition, pageable);
+
+        // then
+        System.out.println(result.getContent());
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
@@ -11,7 +11,7 @@ import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.opinion.dto.ProcessType;
 import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
-import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -60,10 +60,10 @@ class OpinionServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<QuestionResponseDto> questionPage = new PageImpl<>(questions, pageable, 2);
 
-        when(questionRepository.searchQuestions(anyInt(), any(QuestionSearchRequestDto.class), any(Pageable.class))).thenReturn(questionPage);
+        when(questionRepository.searchQuestions(anyInt(), any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(questionPage);
 
         // when
-        QuestionSearchRequestDto searchCondition = QuestionSearchRequestDto.builder()
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
                 .searchType(SearchType.BUYER)
                 .keyword("user")
                 .searchPeriod(SearchPeriod.TODAY)

--- a/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
+import com.farmdora.farmdora.opinion.repository.ReviewRepository;
 import com.farmdora.farmdora.order.dto.SearchPeriod;
 import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
@@ -31,6 +33,9 @@ class OpinionServiceTest {
 
     @Mock
     private QuestionRepository questionRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @InjectMocks
     private OpinionService opinionService;
@@ -71,6 +76,44 @@ class OpinionServiceTest {
                 .sort(Sort.OLDEST)
                 .build();
         PageResponseDto<QuestionResponseDto> result = opinionService.searchQuestions(1, searchCondition, pageable);
+
+        // then
+        assertThat(result.getContents().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("리뷰 목록 검색 서비스 로직 테스트")
+    void testSearchReviews() {
+        // given
+        List<ReviewResponseDto> reviews = List.of(
+                ReviewResponseDto.builder()
+                        .saleTitle("sale")
+                        .reviewContent("review1")
+                        .writer("user1")
+                        .createdDate(LocalDateTime.now())
+                        .score((byte) 4)
+                        .build(),
+                ReviewResponseDto.builder()
+                        .saleTitle("sale")
+                        .reviewContent("review2")
+                        .writer("user2")
+                        .createdDate(LocalDateTime.now())
+                        .score((byte) 3)
+                        .build()
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<ReviewResponseDto> reviewPage = new PageImpl<>(reviews, pageable, 2);
+
+        when(reviewRepository.searchReviews(any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(reviewPage);
+
+        // when
+        OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
+                .searchType(SearchType.PRODUCT)
+                .keyword("user")
+                .searchPeriod(SearchPeriod.TODAY)
+                .sort(Sort.OLDEST)
+                .build();
+        PageResponseDto<ReviewResponseDto> result = opinionService.searchReviews(searchCondition, pageable);
 
         // then
         assertThat(result.getContents().size()).isEqualTo(2);

--- a/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
@@ -1,4 +1,4 @@
-package com.farmdora.farmdora.question.service;
+package com.farmdora.farmdora.opinion.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -9,10 +9,10 @@ import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.order.dto.SearchPeriod;
 import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.question.dto.ProcessType;
-import com.farmdora.farmdora.question.dto.QuestionResponseDto;
-import com.farmdora.farmdora.question.dto.QuestionSearchRequestDto;
-import com.farmdora.farmdora.question.repository.QuestionRepository;
+import com.farmdora.farmdora.opinion.dto.ProcessType;
+import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
+import com.farmdora.farmdora.opinion.dto.QuestionSearchRequestDto;
+import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -27,13 +27,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
-class QuestionServiceTest {
+class OpinionServiceTest {
 
     @Mock
     private QuestionRepository questionRepository;
 
     @InjectMocks
-    private QuestionService questionService;
+    private OpinionService opinionService;
 
     @Test
     @DisplayName("문의 목록 검색 서비스 로직 테스트")
@@ -70,7 +70,7 @@ class QuestionServiceTest {
                 .processTypes(List.of(ProcessType.WAIT))
                 .sort(Sort.OLDEST)
                 .build();
-        PageResponseDto<QuestionResponseDto> result = questionService.searchQuestions(1, searchCondition, pageable);
+        PageResponseDto<QuestionResponseDto> result = opinionService.searchQuestions(1, searchCondition, pageable);
 
         // then
         assertThat(result.getContents().size()).isEqualTo(2);

--- a/src/test/java/com/farmdora/farmdora/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/order/repository/OrderRepositoryTest.java
@@ -44,6 +44,7 @@ class OrderRepositoryTest {
     private TestEntityManager em;
 
     private Seller seller;
+    private List<Integer> orderIds = new ArrayList<>();
 
     @BeforeEach
     void setUp() {
@@ -122,6 +123,7 @@ class OrderRepositoryTest {
                         .build();
             }
             em.persist(order);
+            orderIds.add(order.getId());
 
             OrderOption orderOption1 = OrderOption.builder()
                     .order(order)
@@ -196,7 +198,6 @@ class OrderRepositoryTest {
     @DisplayName("주문PK를 통해 주문 상세 조회")
     void testSearchOrderDetailsByIds() {
         // given
-        List<Integer> orderIds = new ArrayList<>(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
 
         // when
         List<OrderDetailDto> orderDetails = orderRepository.findOrderDetailsByIds(orderIds, Sort.LATEST);

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -1,119 +1,34 @@
 package com.farmdora.farmdora.sale.controller;
 
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
-import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
-import com.farmdora.farmdora.common.response.PageResponseDto;
-import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
-import com.farmdora.farmdora.sale.dto.SaleStatus;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import java.util.List;
-import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.MediaType;
 
-class SaleControllerTest extends ControllerTest {
-
-    private SaleSearchRequestDto searchCondition;
-    private PageResponseDto<SaleSearchResponseDto> result;
-
-    @BeforeEach
-    void setUp() {
-        searchCondition  = SaleSearchRequestDto.builder()
-                .keyword("상추")
-                .sort(Sort.LATEST)
-                .filters(Set.of(SaleStatus.INSTOCK))
-                .typeBigId((short) 1)
-                .typeId((short) 2)
-                .build();
-
-        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
-                SaleSearchResponseDto.builder()
-                        .saleId(1)
-                        .title("상추1")
-                        .price(10000)
-                        .isBlind(false)
-                        .stock(100)
-                        .orderCount(3L)
-                        .build(),
-                SaleSearchResponseDto.builder()
-                        .saleId(2)
-                        .title("상추2")
-                        .price(20000)
-                        .isBlind(false)
-                        .stock(200)
-                        .orderCount(2L)
-                        .build()
-        );
-        Page<SaleSearchResponseDto> pages = new PageImpl<>(saleSearchResponseDtos);
-        result = new PageResponseDto(pages.getContent(), pages);
-    }
-
-    @Nested
-    @DisplayName("상품 목록 조회 API 테스트")
-    class SearchSales {
-
-        @Test
-        @DisplayName("JSON으로 상품 목록 조회 API 테스트")
-        void testSearchSalesByJsonAPI() throws Exception {
-            // given
-            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
-
-            // when
-            // then
-            mvc.perform(post("/my/seller/sale/search")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(new ObjectMapper().writeValueAsString(searchCondition)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
-        }
-
-        @Test
-        @DisplayName("파라미터로 상품 목록 조회 API 테스트")
-        void testSearchSalesByParamsAPI() throws Exception {
-            // given
-            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
-
-            // when
-            // then
-            mvc.perform(get("/my/seller/sale/search")
-                            .param("keyword", "상추")
-                            .param("sort", "LATEST")
-                            .param("typeBigId", "1")
-                            .param("typeId", "2"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
-        }
-    }
+public class SaleControllerTest extends ControllerTest {
 
     @Nested
     @DisplayName("상품 상세 조회 API 테스트")
     class GetSaleDetail {
 
         @Test
-        @DisplayName("상품 상세 조회 API 테스트")
+        @DisplayName("상품 상세 조회 API 성공")
         void testGetSaleDetailAPI() throws Exception {
             // given
             SaleDetailDto saleDetailDto = SaleDetailDto.builder()
@@ -127,7 +42,7 @@ class SaleControllerTest extends ControllerTest {
 
             // when
             // then
-            mvc.perform(get("/my/seller/sale/{saleId}", 1)
+            mvc.perform(get("/sale/{saleId}", 1)
                             .param("userId", "1"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
@@ -144,7 +59,7 @@ class SaleControllerTest extends ControllerTest {
 
             // when
             // then
-            mvc.perform(get("/my/seller/sale/{saleId}", 1)
+            mvc.perform(get("/sale/{saleId}", 1)
                             .param("userId", "1"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
@@ -152,5 +67,50 @@ class SaleControllerTest extends ControllerTest {
         }
     }
 
+    @Nested
+    @DisplayName("관련 상품 목록 조회 API 테스트")
+    class GetRelatedSales {
+        @Test
+        @DisplayName("관련 상품 목록 조회 API 성공")
+        void testGetRelatedSalesAPI() throws Exception {
+            // given
+            List<SaleRelatedDto> relatedSales = List.of(
+                    SaleRelatedDto.builder()
+                            .saleId(1)
+                            .isLike(true)
+                            .reviewCount(10L)
+                            .build(),
+                    SaleRelatedDto.builder()
+                            .saleId(1)
+                            .isLike(true)
+                            .reviewCount(10L)
+                            .build()
+            );
+            when(saleService.getRelatedSales(anyInt(), anyInt(), any(Pageable.class))).thenReturn(relatedSales);
 
+            // when
+            // then
+            mvc.perform(get("/sale/related/{saleId}", 1)
+                            .param("userId", "1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(GET_RELATED_SALES_SUCCESS.getMessage())))
+                    .andExpect(jsonPath("$.data.size()", equalTo(2)));
+        }
+
+        @Test
+        @DisplayName("관련 상품 목록 조회시 상품이 존재하지 않을 경우 예외 발생 API 테스트")
+        void testGetRelatedSalesAPI_SaleNotFoundException() throws Exception {
+            // given
+            when(saleService.getRelatedSales(anyInt(), anyInt(), any(Pageable.class))).thenThrow(new ResourceNotFoundException("Sale", 1));
+
+            // when
+            // then
+            mvc.perform(get("/sale/related/{saleId}", 1)
+                            .param("userId", "1"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("Sale 데이터가 존재하지 않습니다 : '1'")));
+        }
+    }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -2,6 +2,7 @@ package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -12,6 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
@@ -19,6 +22,8 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public class SaleControllerTest extends ControllerTest {
@@ -112,5 +117,27 @@ public class SaleControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("Sale 데이터가 존재하지 않습니다 : '1'")));
         }
+    }
+
+    @Test
+    @DisplayName("상품의 리뷰 목록 조회 API 테스트")
+    void testGetSaleReviewsAPI() throws Exception {
+        // given
+        List<ReviewDetailDto> reviews = List.of(
+            new ReviewDetailDto(),
+            new ReviewDetailDto()
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+        PageImpl<ReviewDetailDto> reviewDetails = new PageImpl<>(reviews, pageable, 2);
+        PageResponseDto<ReviewDetailDto> result = new PageResponseDto<>(reviewDetails.getContent(), reviewDetails);
+        when(saleService.getSaleReviews(anyInt(), any(Pageable.class))).thenReturn(result);
+
+        // when
+        // then
+        mvc.perform(get("/sale/review/{saleId}", 1))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(SEARCH_REVIEWS_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.data.contents.size()", equalTo(2)));
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -2,6 +2,7 @@ package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -14,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
@@ -139,5 +141,51 @@ public class SaleControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.status", equalTo(200)))
                 .andExpect(jsonPath("$.message", equalTo(SEARCH_REVIEWS_SUCCESS.getMessage())))
                 .andExpect(jsonPath("$.data.contents.size()", equalTo(2)));
+    }
+
+    @Nested
+    @DisplayName("상품의 문의 목록 조회 API 테스트")
+    class GetSaleQuestionsTests {
+
+        @Test
+        @DisplayName("상품의 문의 목록 조회 API 성공")
+        void testGetSaleQuestionsAPI() throws Exception {
+            // given
+            List<QuestionResponseDto> questions = List.of(
+                    QuestionResponseDto.builder()
+                            .title("question1")
+                            .writer("user1")
+                            .build(),
+                    QuestionResponseDto.builder()
+                            .title("question2")
+                            .writer("user2")
+                            .build()
+            );
+            PageResponseDto<QuestionResponseDto> result = new PageResponseDto<>();
+            result.setContents(questions);
+            when(saleService.getSaleQuestions(anyInt(), any(Pageable.class))).thenReturn(result);
+
+            // when
+            // then
+            mvc.perform(get("/sale/question/{saleId}", 1))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(SEARCH_QUESTION_SUCCESS.getMessage())));
+        }
+
+        @Test
+        @DisplayName("상품의 문의 목록 조회시 상품이 존재하지 않을 경우 예외 발생 API 테스트")
+        void testGetSaleQuestionsAPI_ResourceNotFoundException() throws Exception {
+            // given
+            when(saleService.getSaleQuestions(anyInt(), any(Pageable.class)))
+                    .thenThrow(new ResourceNotFoundException("Sale", 1));
+
+            // when
+            // then
+            mvc.perform(get("/sale/question/{saleId}", 1))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.message", equalTo("Sale 데이터가 존재하지 않습니다 : '1'")));
+        }
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SellerSaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SellerSaleControllerTest.java
@@ -66,14 +66,14 @@ class SellerSaleControllerTest extends ControllerTest {
     }
 
     @Nested
-    @DisplayName("상품 목록 조회 API 테스트")
+    @DisplayName("상품 목록 검색 API 테스트")
     class SearchSales {
 
         @Test
         @DisplayName("JSON으로 상품 목록 조회 API 테스트")
         void testSearchSalesByJsonAPI() throws Exception {
             // given
-            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+            when(sellerSaleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
 
             // when
             // then
@@ -89,7 +89,7 @@ class SellerSaleControllerTest extends ControllerTest {
         @DisplayName("파라미터로 상품 목록 조회 API 테스트")
         void testSearchSalesByParamsAPI() throws Exception {
             // given
-            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+            when(sellerSaleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
 
             // when
             // then

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SellerSaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SellerSaleControllerTest.java
@@ -1,0 +1,106 @@
+package com.farmdora.farmdora.sale.controller;
+
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_SALES_SUCCESS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.farmdora.farmdora.ControllerTest;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+
+class SellerSaleControllerTest extends ControllerTest {
+
+    private SaleSearchRequestDto searchCondition;
+    private PageResponseDto<SaleSearchResponseDto> result;
+
+    @BeforeEach
+    void setUp() {
+        searchCondition  = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeBigId((short) 1)
+                .typeId((short) 2)
+                .build();
+
+        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
+                SaleSearchResponseDto.builder()
+                        .saleId(1)
+                        .title("상추1")
+                        .price(10000)
+                        .isBlind(false)
+                        .stock(100)
+                        .orderCount(3L)
+                        .build(),
+                SaleSearchResponseDto.builder()
+                        .saleId(2)
+                        .title("상추2")
+                        .price(20000)
+                        .isBlind(false)
+                        .stock(200)
+                        .orderCount(2L)
+                        .build()
+        );
+        Page<SaleSearchResponseDto> pages = new PageImpl<>(saleSearchResponseDtos);
+        result = new PageResponseDto(pages.getContent(), pages);
+    }
+
+    @Nested
+    @DisplayName("상품 목록 조회 API 테스트")
+    class SearchSales {
+
+        @Test
+        @DisplayName("JSON으로 상품 목록 조회 API 테스트")
+        void testSearchSalesByJsonAPI() throws Exception {
+            // given
+            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+            // when
+            // then
+            mvc.perform(post("/my/seller/sale/search")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(new ObjectMapper().writeValueAsString(searchCondition)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        }
+
+        @Test
+        @DisplayName("파라미터로 상품 목록 조회 API 테스트")
+        void testSearchSalesByParamsAPI() throws Exception {
+            // given
+            when(saleService.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+
+            // when
+            // then
+            mvc.perform(get("/my/seller/sale/search")
+                            .param("keyword", "상추")
+                            .param("sort", "LATEST")
+                            .param("typeBigId", "1")
+                            .param("typeId", "2"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.message", equalTo(SEARCH_SALES_SUCCESS.getMessage())));
+        }
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.OrderOption;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleType;
+import com.farmdora.farmdora.entity.SaleTypeBig;
+import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Transactional
+@Import(AuditConfig.class)
+class CustomSaleRepositoryTest {
+
+    @Autowired
+    private SaleRepository saleRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private Seller seller;
+    private SaleTypeBig bigType;
+    private SaleType smallType;
+
+    @BeforeEach
+    void setUp() {
+        seller = new Seller();
+        em.persist(seller);
+
+        bigType = SaleTypeBig.builder()
+                .id((short) 1)
+                .name("과일")
+                .build();
+        em.persist(bigType);
+
+        smallType = SaleType.builder()
+                .id((short) 1)
+                .name("사과")
+                .saleTypeBig(bigType)
+                .build();
+        em.persist(smallType);
+
+        for (int i = 0; i < 10; i++) {
+            Sale sale = Sale.builder()
+                    .title("상추" + (i + 1))
+                    .isBlind(false)
+                    .seller(seller)
+                    .type(smallType)
+                    .build();
+            em.persist(sale);
+
+            Option option1 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .sale(sale)
+                    .build();
+            Option option2 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .sale(sale)
+                    .build();
+            em.persist(option1);
+            em.persist(option2);
+
+            OrderOption orderOption1 = OrderOption.builder()
+                    .option(option1)
+                    .build();
+            OrderOption orderOption2 = OrderOption.builder()
+                    .option(option2)
+                    .build();
+            em.persist(orderOption1);
+            em.persist(orderOption2);
+        }
+    }
+
+    @Test
+    @DisplayName("상품 목록 검색 및 조회 테스트")
+    void testSearchSales() {
+        // given
+        Integer sellerId = seller.getId();
+        System.out.println(sellerId);
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeBigId(bigType.getId())
+                .typeId(smallType.getId())
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<SaleDto> result = saleRepository.searchSales(sellerId, searchCondition, pageable);
+
+        // then
+        assertThat(result.getContent().size()).isEqualTo(10);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("상품 목록 주문 수 조회 테스트")
+    void testSearchOrderCounts() {
+        // given
+        List<Sale> sales = saleRepository.findAll();
+        List<Integer> saleIds = sales.stream().map(s -> s.getId()).collect(Collectors.toList());
+
+        // when
+        List<SaleOrderCountDto> orderCounts = saleRepository.searchSaleOrderCount(saleIds);
+
+        // then
+        assertThat(orderCounts.size()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleFileRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleFileRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,5 +47,35 @@ class SaleFileRepositoryTest {
 
         // then
         assertThat(saleFiles.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("findBySaleIdAndIsMainIsTrue() 쿼리메서드 테스트")
+    void testFindBySaleIdAndIsMainIsTrue() {
+        // given
+        Sale sale = new Sale();
+        em.persist(sale);
+
+        SaleFile saleFile1 = SaleFile.builder()
+                .sale(sale)
+                .isMain(false)
+                .build();
+        SaleFile saleFile2 = SaleFile.builder()
+                .sale(sale)
+                .saveFile("saveFile")
+                .isMain(true)
+                .build();
+        em.persist(saleFile1);
+        em.persist(saleFile2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<SaleFile> saleFile = saleFileRepository.findBySaleIdAndIsMainIsTrue(sale.getId());
+
+        // then
+        assertThat(saleFile.isPresent()).isEqualTo(true);
+        assertThat(saleFile.get().getSaveFile()).isEqualTo("saveFile");
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
@@ -89,9 +89,6 @@ class SaleRepositoryTest {
 
         // when
         List<SaleRelatedInfoDto> sales = saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(type, excludeSale.getId(), pageable);
-//        for (SaleRelatedInfoDto info : sales) {
-//            System.out.println(info.toString());
-//        }
 
         // then
         assertThat(sales.size()).isEqualTo(9);

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
@@ -2,36 +2,23 @@ package com.farmdora.farmdora.sale.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Like;
 import com.farmdora.farmdora.entity.Option;
-import com.farmdora.farmdora.entity.OrderOption;
+import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleType;
-import com.farmdora.farmdora.entity.SaleTypeBig;
-import com.farmdora.farmdora.entity.Seller;
-import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleStatus;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Transactional
-@Import(AuditConfig.class)
 class SaleRepositoryTest {
 
     @Autowired
@@ -40,97 +27,73 @@ class SaleRepositoryTest {
     @Autowired
     private TestEntityManager em;
 
-    private Seller seller;
-    private SaleTypeBig bigType;
-    private SaleType smallType;
+    @Test
+    @DisplayName("findTop10ByTypeAndIdNotOrderByIdDesc 쿼리메서드 테스트")
+    void testFindTop10ByTypeAndIdNotOrderByIdDesc() {
+        // given
+        User user = new User();
+        em.persist(user);
 
-    @BeforeEach
-    void setUp() {
-        seller = new Seller();
-        em.persist(seller);
-
-        bigType = SaleTypeBig.builder()
+        SaleType type = SaleType.builder()
                 .id((short) 1)
-                .name("과일")
+                .name("소분류1")
                 .build();
-        em.persist(bigType);
+        em.persist(type);
 
-        smallType = SaleType.builder()
-                .id((short) 1)
-                .name("사과")
-                .saleTypeBig(bigType)
+        Sale excludeSale = Sale.builder()
+                .type(type)
                 .build();
-        em.persist(smallType);
+        em.persist(excludeSale);
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 1; i <= 9; i++) {
             Sale sale = Sale.builder()
-                    .title("상추" + (i + 1))
-                    .isBlind(false)
-                    .seller(seller)
-                    .type(smallType)
+                    .title("title" + i)
+                    .type(type)
                     .build();
             em.persist(sale);
 
-            Option option1 = Option.builder()
-                    .price(100 * (i + 1))
-                    .quantity(100)
-                    .sale(sale)
-                    .build();
-            Option option2 = Option.builder()
-                    .price(100 * (i + 1))
-                    .quantity(100)
-                    .sale(sale)
-                    .build();
-            em.persist(option1);
-            em.persist(option2);
+            if (i % 2 == 0) {
+                Review review1 = Review.builder()
+                        .sale(sale)
+                        .score((byte) 3)
+                        .build();
+                Review review2 = Review.builder()
+                        .sale(sale)
+                        .score((byte) 4)
+                        .build();
+                em.persist(review1);
+                em.persist(review2);
+            } else {
+                Like like = Like.builder()
+                        .saleId(sale.getId())
+                        .userId(user.getUserId())
+                        .build();
+                em.persist(like);
 
-            OrderOption orderOption1 = OrderOption.builder()
-                    .option(option1)
-                    .build();
-            OrderOption orderOption2 = OrderOption.builder()
-                    .option(option2)
-                    .build();
-            em.persist(orderOption1);
-            em.persist(orderOption2);
+                Option option1 = Option.builder()
+                        .sale(sale)
+                        .price(1000)
+                        .build();
+                Option option2 = Option.builder()
+                        .sale(sale)
+                        .price(2000)
+                        .build();
+                em.persist(option1);
+                em.persist(option2);
+            }
         }
-    }
+        em.flush();
+        em.clear();
 
-    @Test
-    @DisplayName("상품 목록 검색 및 조회 테스트")
-    void testSearchSales() {
-        // given
-        Integer sellerId = seller.getId();
-        System.out.println(sellerId);
-        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
-                .keyword("상추")
-                .sort(Sort.LATEST)
-                .filters(Set.of(SaleStatus.INSTOCK))
-                .typeBigId(bigType.getId())
-                .typeId(smallType.getId())
-                .build();
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        Page<SaleDto> result = saleRepository.searchSales(sellerId, searchCondition, pageable);
+        List<SaleRelatedInfoDto> sales = saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(type, excludeSale.getId(), pageable);
+//        for (SaleRelatedInfoDto info : sales) {
+//            System.out.println(info.toString());
+//        }
 
         // then
-        assertThat(result.getContent().size()).isEqualTo(10);
-        assertThat(result.getTotalPages()).isEqualTo(1);
-        assertThat(result.getNumber()).isEqualTo(0);
-        assertThat(result.getTotalElements()).isEqualTo(10);
-    }
-
-    @Test
-    @DisplayName("상품 목록 주문 수 조회 테스트")
-    void testSearchOrderCounts() {
-        // given
-        List<Sale> sales = saleRepository.findAll();
-        List<Integer> saleIds = sales.stream().map(s -> s.getId()).collect(Collectors.toList());
-
-        // when
-        List<SaleOrderCountDto> orderCounts = saleRepository.searchSaleOrderCount(saleIds);
-
-        // then
-        assertThat(orderCounts.size()).isEqualTo(10);
+        assertThat(sales.size()).isEqualTo(9);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -15,7 +15,9 @@ import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import com.farmdora.farmdora.opinion.repository.ReviewRepository;
+import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
@@ -24,6 +26,7 @@ import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -54,6 +58,9 @@ class SaleServiceTest {
 
     @Mock
     private ReviewRepository reviewRepository;
+
+    @Mock
+    private QuestionRepository questionRepository;
 
     @InjectMocks
     private SaleService saleService;
@@ -220,6 +227,42 @@ class SaleServiceTest {
         PageResponseDto<ReviewDetailDto> result = saleService.getSaleReviews(1, pageable);
 
         // then
+        assertThat(result.getContents().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("상품의 문의 목록 조회 서비스 레이어 테스트")
+    void testGetSaleQuestions() {
+        // given
+        Integer saleId = 1;
+        Sale mockSale = Sale.builder()
+                .id(saleId)
+                .build();
+        when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
+
+        List<QuestionResponseDto> questionPages = List.of(
+                QuestionResponseDto.builder()
+                        .id(1)
+                        .title("question1")
+                        .writer("user1")
+                        .createdDate(LocalDateTime.now())
+                        .build(),
+                QuestionResponseDto.builder()
+                        .id(2)
+                        .title("question2")
+                        .writer("user2")
+                        .createdDate(LocalDateTime.now())
+                        .build()
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<QuestionResponseDto> questions = new PageImpl<>(questionPages, pageable, questionPages.size());
+        when(questionRepository.findQuestionsBySaleId(any(Sale.class), any(Pageable.class))).thenReturn(questions);
+
+        // when
+        PageResponseDto<QuestionResponseDto> result = saleService.getSaleQuestions(saleId, pageable);
+
+        // then
+        System.out.println(result.toString());
         assertThat(result.getContents().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -12,8 +12,11 @@ import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.entity.Option;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
+import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
+import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleStatus;
@@ -28,6 +31,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -131,66 +135,137 @@ class SaleServiceTest {
         assertThat(result.getContents().size()).isEqualTo(2);
     }
 
-    @Test
-    @DisplayName("상품 상세 정보 조회 서비스 레이어 테스트")
-    void testGetSaleDetail() {
-        // given
-        Sale mockSale = Sale.builder()
-                .id(1)
-                .title("상추")
-                .content("유기농 상추")
-                .origin("국산")
-                .build();
-        when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
+    @Nested
+    @DisplayName("판매자의 상품 목록 검색 및 조회 서비스 레이어 테스트")
+    class GetSaleDetailsTests {
 
-        List<Option> options = List.of(
-                Option.builder()
-                        .id(1)
-                        .sale(mockSale)
-                        .name("상추 옵션1")
-                        .price(1000)
-                        .build(),
-                Option.builder()
-                        .id(2)
-                        .sale(mockSale)
-                        .name("상추 옵션2")
-                        .price(2000)
-                        .build()
-        );
-        when(optionRepository.findAllBySale(any(Sale.class))).thenReturn(options);
+        @Test
+        @DisplayName("상품 상세 정보 조회 성공")
+        void testGetSaleDetail() {
+            // given
+            Sale mockSale = Sale.builder()
+                    .id(1)
+                    .title("상추")
+                    .content("유기농 상추")
+                    .origin("국산")
+                    .build();
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
 
-        List<SaleFile> saleFiles = List.of(
-                SaleFile.builder()
-                        .sale(mockSale)
-                        .saveFile("URL1")
-                        .build(),
-                SaleFile.builder()
-                        .sale(mockSale)
-                        .saveFile("URL2")
-                        .build()
-        );
-        when(saleFileRepository.findAllBySale(any(Sale.class))).thenReturn(saleFiles);
+            List<Option> options = List.of(
+                    Option.builder()
+                            .id(1)
+                            .sale(mockSale)
+                            .name("상추 옵션1")
+                            .price(1000)
+                            .build(),
+                    Option.builder()
+                            .id(2)
+                            .sale(mockSale)
+                            .name("상추 옵션2")
+                            .price(2000)
+                            .build()
+            );
+            when(optionRepository.findAllBySale(any(Sale.class))).thenReturn(options);
 
-        when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
+            List<SaleFile> saleFiles = List.of(
+                    SaleFile.builder()
+                            .sale(mockSale)
+                            .saveFile("URL1")
+                            .build(),
+                    SaleFile.builder()
+                            .sale(mockSale)
+                            .saveFile("URL2")
+                            .build()
+            );
+            when(saleFileRepository.findAllBySale(any(Sale.class))).thenReturn(saleFiles);
 
-        // when
-        SaleDetailDto saleDetail = saleService.getSaleDetail(1, 1);
+            when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
 
-        // then
-        assertThat(saleDetail.getContent()).isEqualTo("유기농 상추");
-        assertThat(saleDetail.getOptions().size()).isEqualTo(2);
-        assertThat(saleDetail.getFiles().size()).isEqualTo(2);
+            // when
+            SaleDetailDto saleDetail = saleService.getSaleDetail(1, 1);
+
+            // then
+            assertThat(saleDetail.getContent()).isEqualTo("유기농 상추");
+            assertThat(saleDetail.getOptions().size()).isEqualTo(2);
+            assertThat(saleDetail.getFiles().size()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("상세정보를 조회하고자 하는 상품이 존재하지 않을 경우 예외 발생테스트")
+        void testGetSaleDetail_SaleNotFoundException() {
+            // given
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> saleService.getSaleDetail(1, 1))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
     }
 
-    @Test
-    @DisplayName("상세정보를 조회하고자 하는 상품이 존재하지 않을 경우 예외 발생테스트")
-    void testGetSaleDetail_SaleNotFoundException() {
-        // given
-        when(saleRepository.findById(anyInt())).thenReturn(Optional.empty());
+    @Nested
+    @DisplayName("관련 상품 목록 조회 서비스 레이어 테스트")
+    class GetRelatedSales {
 
-        // when
-        // then
-        assertThatThrownBy(() -> saleService.getSaleDetail(1, 1))
-                .isInstanceOf(ResourceNotFoundException.class);
+        @Test
+        @DisplayName("관련 상품 목록 조회 성공")
+        void testGetRelatedSales() {
+            // given
+            Sale mockSale = Sale.builder()
+                    .id(1)
+                    .type(new SaleType())
+                    .build();
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.of(mockSale));
+
+            List<SaleRelatedInfoDto> relatedSaleDetails = List.of(
+                    SaleRelatedInfoDto.builder()
+                            .saleId(2)
+                            .title("sale2")
+                            .price(10000)
+                            .reviewCount(10L)
+                            .score(3.5)
+                            .build(),
+                    SaleRelatedInfoDto.builder()
+                            .saleId(3)
+                            .title("sale3")
+                            .price(20000)
+                            .reviewCount(12L)
+                            .score(4.0)
+                            .build()
+            );
+            when(saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(any(SaleType.class), anyInt(), any(Pageable.class))).thenReturn(relatedSaleDetails);
+
+            when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
+
+            SaleFile mockSaleFile = SaleFile.builder()
+                    .sale(mockSale)
+                    .isMain(true)
+                    .originFile("origin_file")
+                    .saveFile("save_file")
+                    .build();
+            when(saleFileRepository.findBySaleIdAndIsMainIsTrue(anyInt())).thenReturn(Optional.of(mockSaleFile));
+
+            // when
+            Pageable pageable = PageRequest.of(0, 10);
+            List<SaleRelatedDto> relatedSales = saleService.getRelatedSales(1, 1, pageable);
+
+            // then
+            assertThat(relatedSales.size()).isEqualTo(2);
+            assertThat(relatedSales.get(0).getSaleId()).isEqualTo(2);
+            assertThat(relatedSales.get(1).getSaleId()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("관련상품을 조회할 상품이 존재하지 않을 경우 예외 발생")
+        void testGetRelatedSales_ResourceNotFoundException() {
+            // given
+            when(saleRepository.findById(anyInt())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            Pageable pageable = PageRequest.of(0, 10);
+            assertThatThrownBy(() -> saleService.getRelatedSales(1, 1, pageable))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
@@ -17,24 +16,16 @@ import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.entity.User;
 import com.farmdora.farmdora.opinion.repository.ReviewRepository;
-import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
-import com.farmdora.farmdora.sale.dto.SaleStatus;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
-import com.farmdora.farmdora.sale.mapper.SaleMapper;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -65,86 +55,11 @@ class SaleServiceTest {
     @Mock
     private ReviewRepository reviewRepository;
 
-    @Mock
-    private SaleMapper saleMapper;
-
     @InjectMocks
     private SaleService saleService;
 
-    @Test
-    @DisplayName("판매자의 상품 목록 검색 및 조회 서비스 레이어 테스트")
-    void testSearchSales() {
-        // given
-        List<SaleDto> saleDtos = List.of(
-                SaleDto.builder()
-                        .saleId(1)
-                        .title("상추1")
-                        .price(10000)
-                        .isBlind(false)
-                        .stock(100)
-                        .build(),
-                SaleDto.builder()
-                        .saleId(2)
-                        .title("상추2")
-                        .price(20000)
-                        .isBlind(false)
-                        .stock(200)
-                        .build()
-        );
-        Page<SaleDto> saleSearchResponsePages = new PageImpl<>(saleDtos);
-        when(saleRepository.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(saleSearchResponsePages);
-
-        List<SaleOrderCountDto> orderCounts = List.of(
-                SaleOrderCountDto.builder()
-                        .saleId(1)
-                        .orderCount(1L)
-                        .build(),
-                SaleOrderCountDto.builder()
-                        .saleId(2)
-                        .orderCount(1L)
-                        .build()
-        );
-        when(saleRepository.searchSaleOrderCount(anyList())).thenReturn(orderCounts);
-
-        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
-                SaleSearchResponseDto.builder()
-                        .saleId(1)
-                        .title("상추1")
-                        .price(10000)
-                        .isBlind(false)
-                        .stock(100)
-                        .orderCount(1L)
-                        .build(),
-                SaleSearchResponseDto.builder()
-                        .saleId(2)
-                        .title("상추2")
-                        .price(20000)
-                        .isBlind(false)
-                        .stock(200)
-                        .orderCount(2L)
-                        .build()
-        );
-        when(saleMapper.mapToSaleSearchResponseDto(anyList(), anyList(), anyList())).thenReturn(saleSearchResponseDtos);
-
-        // when
-        Integer sellerId = 1;
-        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
-                .keyword("상추")
-                .sort(Sort.LATEST)
-                .filters(Set.of(SaleStatus.INSTOCK))
-                .typeId((short) 1)
-                .typeBigId((short) 1)
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);
-
-        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(sellerId, searchCondition, pageable);
-
-        // then
-        assertThat(result.getContents().size()).isEqualTo(2);
-    }
-
     @Nested
-    @DisplayName("판매자의 상품 목록 검색 및 조회 서비스 레이어 테스트")
+    @DisplayName("상품 상세 정보 조회 서비스 레이어 테스트")
     class GetSaleDetailsTests {
 
         @Test

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -10,10 +10,15 @@ import static org.mockito.Mockito.when;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Order;
+import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.entity.SaleType;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.opinion.repository.ReviewRepository;
 import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
@@ -56,6 +61,9 @@ class SaleServiceTest {
 
     @Mock
     private LikeRepository likeRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @Mock
     private SaleMapper saleMapper;
@@ -267,5 +275,36 @@ class SaleServiceTest {
             assertThatThrownBy(() -> saleService.getRelatedSales(1, 1, pageable))
                     .isInstanceOf(ResourceNotFoundException.class);
         }
+    }
+
+    @Test
+    @DisplayName("상품의 리뷰 목록 조회 서비스 레이어 테스트")
+    void testGetSaleReviews() {
+        // given
+        Order order = Order.builder()
+                .user(User.builder().name("user").build())
+                .build();
+
+        List<Review> reviews = List.of(
+            Review.builder()
+                    .order(order)
+                    .content("review1")
+                    .score((byte) 2)
+                    .build(),
+            Review.builder()
+                    .order(order)
+                    .content("review2")
+                    .score((byte) 3)
+                    .build()
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+        PageImpl<Review> reviewPages = new PageImpl<>(reviews, pageable, 2);
+        when(reviewRepository.findAllBySaleId(anyInt(), any(Pageable.class))).thenReturn(reviewPages);
+
+        // when
+        PageResponseDto<ReviewDetailDto> result = saleService.getSaleReviews(1, pageable);
+
+        // then
+        assertThat(result.getContents().size()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/service/SellerSaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SellerSaleServiceTest.java
@@ -1,0 +1,114 @@
+package com.farmdora.farmdora.sale.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.sale.mapper.SaleMapper;
+import com.farmdora.farmdora.sale.repository.SaleRepository;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class SellerSaleServiceTest {
+
+    @Mock
+    private SaleRepository saleRepository;
+
+    @Mock
+    private SaleMapper saleMapper;
+
+    @InjectMocks
+    private SellerSaleService saleService;
+
+    @Test
+    @DisplayName("판매자의 상품 목록 검색 및 조회 서비스 레이어 테스트")
+    void testSearchSales() {
+        // given
+        List<SaleDto> saleDtos = List.of(
+                SaleDto.builder()
+                        .saleId(1)
+                        .title("상추1")
+                        .price(10000)
+                        .isBlind(false)
+                        .stock(100)
+                        .build(),
+                SaleDto.builder()
+                        .saleId(2)
+                        .title("상추2")
+                        .price(20000)
+                        .isBlind(false)
+                        .stock(200)
+                        .build()
+        );
+        Page<SaleDto> saleSearchResponsePages = new PageImpl<>(saleDtos);
+        when(saleRepository.searchSales(anyInt(), any(SaleSearchRequestDto.class), any(Pageable.class))).thenReturn(saleSearchResponsePages);
+
+        List<SaleOrderCountDto> orderCounts = List.of(
+                SaleOrderCountDto.builder()
+                        .saleId(1)
+                        .orderCount(1L)
+                        .build(),
+                SaleOrderCountDto.builder()
+                        .saleId(2)
+                        .orderCount(1L)
+                        .build()
+        );
+        when(saleRepository.searchSaleOrderCount(anyList())).thenReturn(orderCounts);
+
+        List<SaleSearchResponseDto> saleSearchResponseDtos = List.of(
+                SaleSearchResponseDto.builder()
+                        .saleId(1)
+                        .title("상추1")
+                        .price(10000)
+                        .isBlind(false)
+                        .stock(100)
+                        .orderCount(1L)
+                        .build(),
+                SaleSearchResponseDto.builder()
+                        .saleId(2)
+                        .title("상추2")
+                        .price(20000)
+                        .isBlind(false)
+                        .stock(200)
+                        .orderCount(2L)
+                        .build()
+        );
+        when(saleMapper.mapToSaleSearchResponseDto(anyList(), anyList(), anyList())).thenReturn(saleSearchResponseDtos);
+
+        // when
+        Integer sellerId = 1;
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeId((short) 1)
+                .typeBigId((short) 1)
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(sellerId, searchCondition, pageable);
+
+        // then
+        assertThat(result.getContents().size()).isEqualTo(2);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,16 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+
+ncp:
+  image:
+    path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/
+    type: ?type=h&h=192&ttype=png


### PR DESCRIPTION
## 📌 작업 내용
- [x] 상품의 문의 목록 조회 API 구현
- [x] 테스트 케이스 추가
- [x] 테스트 클래스 분리 (QueryDsl, JPA)

<br>
## 💡 필수확인

### 요청 URL
GET /sale/question/{saleId}

### 요청 파라미터
- page : 페이지 번호
- size(선택) : 페이지 당 데이터 수
- saleId : 상품 아이디(PathVariable)

### 응답 본문
- `id` : 문의 아이디
- `title` : 문의 제목
- `writer` : 문의 작성자 이름
- `createdDate` : 문의 작성 시간
- `process` : 문의 답변 상태(`true`/`false`)


```json
{
    "status": 200,
    "message": "문의 목록 조회에 성공하였습니다.",
    "data": {
        "currentPage": 0,
        "pageSize": 10,
        "totalElements": 10,
        "totalPages": 1,
        "hasNext": false,
        "hasPrevious": false,
        "contents": [
            {
                "id": 1,
                "title": "question1",
                "writer": "홍길동",
                "createdDate": "2025-04-18T02:05:42",
                "process": true
            },
            {
                "id": 2,
                "title": "question2",
                "writer": "홍길동",
                "createdDate": "2025-04-18T02:05:42",
                "process": true
            }
        ]
    }
}
```

<br>

## 📆 작업기간
2025.04.18

<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)
