### PR TITLE
[FDORA-1] feat: 인기상품목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/farmdora/farmdora/FarmdoraApplication.java
+++ b/src/main/java/com/farmdora/farmdora/FarmdoraApplication.java
@@ -2,7 +2,9 @@ package com.farmdora.farmdora;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class FarmdoraApplication {
 

--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -11,7 +11,8 @@ public enum SuccessMessage {
     GET_SALE_DETAIL_SUCCESS("상품 상세 조회에 성공하였습니다."),
     SEARCH_QUESTION_SUCCESS("문의 목록 조회에 성공하였습니다."),
     SEARCH_REVIEWS_SUCCESS("리뷰 목록 조회에 성공하였습니다."),
-    GET_RELATED_SALES_SUCCESS("관련 상품 목록 조회에 성공하였습니다.");
+    GET_RELATED_SALES_SUCCESS("관련 상품 목록 조회에 성공하였습니다."),
+    GET_SALES_RANK("상품 랭킹 정보 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/config/RedisConfig.java
+++ b/src/main/java/com/farmdora/farmdora/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.farmdora.farmdora.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALES_RANK;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
@@ -10,6 +11,7 @@ import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.service.SaleService;
 import java.util.List;
@@ -62,5 +64,12 @@ public class SaleController {
         PageResponseDto<QuestionResponseDto> questions = saleService.getSaleQuestions(saleId, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_QUESTION_SUCCESS.getMessage(), questions));
+    }
+
+    @GetMapping("/rank")
+    public ResponseEntity<?> getSaleRank(@PageableDefault Pageable pageable) {
+        PageResponseDto<SaleRankingDto> sales = saleService.getTop50Sales(pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, GET_SALES_RANK.getMessage(), sales));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleRankingDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleRankingDto.java
@@ -1,0 +1,16 @@
+package com.farmdora.farmdora.sale.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaleRankingDto {
+    private Integer saleId;
+    private String title;
+    private Integer minPrice;
+    private Long orderCount;
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
@@ -2,8 +2,10 @@ package com.farmdora.farmdora.sale.repository;
 
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleType;
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +27,15 @@ public interface SaleRepository extends JpaRepository<Sale, Integer>, CustomSale
             Pageable pageable
     );
 
+    @Query("SELECT new com.farmdora.farmdora.sale.dto.SaleRankingDto(" +
+            "s.id, " +
+            "s.title, " +
+            "MIN(o.price), " +
+            "COUNT(oo.id)) " +
+            "FROM Sale s " +
+            "JOIN Option o ON o.sale = s " +
+            "JOIN OrderOption oo ON oo.option = o " +
+            "GROUP BY s.id, s.title " +
+            "ORDER BY COUNT(oo.id) DESC, s.id DESC")
+    Page<SaleRankingDto> findTop50ByOrderCount(Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleRedisService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleRedisService.java
@@ -1,0 +1,62 @@
+package com.farmdora.farmdora.sale.service;
+
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
+import com.farmdora.farmdora.sale.repository.SaleRepository;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SaleRedisService {
+
+    private final SaleRepository saleRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final int SEARCH_SIZE = 50;
+    private static final int PAGE_SIZE = 10;
+    private static final int POPULAR_SALES_DURATION = 10;
+    private static final String POPULAR_SALES_KEY = "popular:sales:page:";
+    private static final String POPULAR_SALES_COUNT_KEY = "popular:sales:count";
+
+    @Scheduled(cron = "0 */10 * * * *")
+    public void cachePopularSales() {
+        log.info("인기 상품 목록을 업데이트합니다...");
+
+        Pageable pageable = PageRequest.of(0, SEARCH_SIZE);
+        Page<SaleRankingDto> sales = saleRepository.findTop50ByOrderCount(pageable);
+        redisTemplate.opsForValue().set(POPULAR_SALES_COUNT_KEY, sales.getTotalElements(), Duration.ofMinutes(10));
+
+        List<SaleRankingDto> content = sales.getContent();
+        int total = content.size();
+
+        for (int page = 0; page < (total + PAGE_SIZE - 1) / PAGE_SIZE; page++) {
+            log.info("실행중...");
+            int start = page * PAGE_SIZE;
+            int end = Math.min(start + PAGE_SIZE, total);
+
+            String key = POPULAR_SALES_KEY + page;
+            List<SaleRankingDto> subList = content.subList(start, end);
+            redisTemplate.opsForValue().set(key, subList, Duration.ofMinutes(POPULAR_SALES_DURATION));
+        }
+
+        log.info("인기 상품 목록 업데이트를 종료합니다...");
+    }
+
+    public List<SaleRankingDto> findSaleRanks(int page) {
+        return (List<SaleRankingDto>) redisTemplate.opsForValue().get(POPULAR_SALES_COUNT_KEY + (page + 1));
+    }
+
+    public Integer findSaleRankCount() {
+        return (Integer) redisTemplate.opsForValue().get(POPULAR_SALES_COUNT_KEY);
+    }
+}
+

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +41,7 @@ public class SaleService {
     private final LikeRepository likeRepository;
     private final ReviewRepository reviewRepository;
     private final QuestionRepository questionRepository;
+    private final SaleRedisService saleRedisService;
 
     @Value("${ncp.image.path}")
     private String imagePath;
@@ -118,6 +120,19 @@ public class SaleService {
 
     @Transactional(readOnly = true)
     public PageResponseDto<SaleRankingDto> getTop50Sales(Pageable pageable) {
+        List<SaleRankingDto> cachedSaleRanks = saleRedisService.findSaleRanks(pageable.getPageNumber());
+        Integer count = saleRedisService.findSaleRankCount();
+
+        if (cachedSaleRanks == null || cachedSaleRanks.isEmpty() || count == null) {
+            log.info("캐시된 데이터가 존재하지 않습니다...DB를 조회합니다...");
+            return getTop50SalesFromDb(pageable);
+        }
+
+        Page<SaleRankingDto> sales = new PageImpl<>(cachedSaleRanks, pageable, count);
+        return new PageResponseDto<>(sales.getContent(), sales);
+    }
+
+    private PageResponseDto<SaleRankingDto> getTop50SalesFromDb(Pageable pageable) {
         Page<SaleRankingDto> sales = saleRepository.findTop50ByOrderCount(pageable);
         return new PageResponseDto<>(sales.getContent(), sales);
     }

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -11,6 +11,7 @@ import com.farmdora.farmdora.opinion.repository.ReviewRepository;
 import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
@@ -113,5 +114,11 @@ public class SaleService {
 
         Page<QuestionResponseDto> questions = questionRepository.findQuestionsBySaleId(sale, pageable);
         return new PageResponseDto<>(questions.getContent(), questions);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<SaleRankingDto> getTop50Sales(Pageable pageable) {
+        Page<SaleRankingDto> sales = saleRepository.findTop50ByOrderCount(pageable);
+        return new PageResponseDto<>(sales.getContent(), sales);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALES_RANK;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEWS_SUCCESS;
@@ -19,6 +20,7 @@ import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -206,5 +208,31 @@ public class SaleControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.message", equalTo("Sale 데이터가 존재하지 않습니다 : '1'")));
         }
+    }
+
+    @Test
+    @DisplayName("상위 50개의 상품 목록 조회 API 테스트")
+    void testGetSaleRank() throws Exception {
+        // given
+        PageResponseDto<SaleRankingDto> sales = new PageResponseDto<>();
+        sales.setPageSize(10);
+        sales.setHasPrevious(false);
+        sales.setHasNext(false);
+        sales.setCurrentPage(0);
+        sales.setPageSize(10);
+        sales.setTotalElements(100L);
+        when(saleService.getTop50Sales(any(Pageable.class))).thenReturn(sales);
+
+        // when
+        // then
+        mvc.perform(get("/sale/rank"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(GET_SALES_RANK.getMessage())))
+                .andExpect(jsonPath("$.data.pageSize", equalTo(10)))
+                .andExpect(jsonPath("$.data.hasPrevious", equalTo(false)))
+                .andExpect(jsonPath("$.data.hasNext", equalTo(false)))
+                .andExpect(jsonPath("$.data.currentPage", equalTo(0)))
+                .andExpect(jsonPath("$.data.totalElements", equalTo(100)));
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.farmdora.farmdora.entity.Like;
 import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Order;
+import com.farmdora.farmdora.entity.OrderOption;
 import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -92,5 +96,52 @@ class SaleRepositoryTest {
 
         // then
         assertThat(sales.size()).isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("상위 50개 상품 목록 조회")
+    void testFindTop50ByOrderCount() {
+        // given
+        for (int i = 0; i < 50; i++) {
+            Sale sale = Sale.builder()
+                    .title("title" + i)
+                    .build();
+            em.persist(sale);
+
+            Option option1 = Option.builder()
+                    .sale(sale)
+                    .price(10000)
+                    .build();
+            Option option2 = Option.builder()
+                    .sale(sale)
+                    .price(20000)
+                    .build();
+            em.persist(option1);
+            em.persist(option2);
+
+            Order order1 = new Order();
+            Order order2 = new Order();
+            em.persist(order1);
+            em.persist(order2);
+
+            OrderOption orderOption1 = OrderOption.builder()
+                    .order(order1)
+                    .option(option1)
+                    .build();
+            OrderOption orderOption2 = OrderOption.builder()
+                    .order(order2)
+                    .option(option2)
+                    .build();
+            em.persist(orderOption1);
+            em.persist(orderOption2);
+        }
+
+        // when
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<SaleRankingDto> sales = saleRepository.findTop50ByOrderCount(pageable);
+        System.out.println(sales.getContent());
+
+        // then
+        assertThat(sales.getContent().size()).isEqualTo(10);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleRedisServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleRedisServiceTest.java
@@ -1,0 +1,86 @@
+package com.farmdora.farmdora.sale.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
+import com.farmdora.farmdora.sale.repository.SaleRepository;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class SaleRedisServiceTest {
+
+    @Mock
+    private SaleRepository saleRepository;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    @InjectMocks
+    private SaleRedisService saleRedisService;
+
+    @Test
+    @DisplayName("인기 상품 목록 캐싱 테스트")
+    void testCachePopularSales() {
+        // given
+        List<SaleRankingDto> dummyList = IntStream.rangeClosed(1, 50)
+                .mapToObj(i -> new SaleRankingDto(i, "상품" + i, i * 1000, null))
+                .toList();
+        Page<SaleRankingDto> dummyPage = new PageImpl<>(dummyList);
+
+        when(saleRepository.findTop50ByOrderCount(any(Pageable.class))).thenReturn(dummyPage);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // when
+        saleRedisService.cachePopularSales();
+
+        // then
+        verify(redisTemplate.opsForValue(), times(6)).set(anyString(), any(), any(Duration.class));
+        verify(valueOperations, times(6)).set(anyString(), any(), any(Duration.class));
+    }
+
+    @Test
+    @DisplayName("캐싱된 인기 상품 목록 조회 테스트")
+    void testFindSaleRanks() {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // when
+        List<SaleRankingDto> saleRanks = saleRedisService.findSaleRanks(0);
+
+        // then
+        verify(valueOperations, times(1)).get(anyString());
+    }
+
+    @Test
+    @DisplayName("캐싱된 인기 상품 목록 개수 조회 테스트")
+    void testFindSaleRankCount() {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // when
+        Integer result = saleRedisService.findSaleRankCount();
+
+        // then
+        verify(valueOperations, times(1)).get(anyString());
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -20,6 +20,7 @@ import com.farmdora.farmdora.opinion.repository.ReviewRepository;
 import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
+import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
@@ -287,5 +288,38 @@ class SaleServiceTest {
         // then
         System.out.println(result.toString());
         assertThat(result.getContents().size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("상품의 랭킹 정보 조회 서비스 레이어 테스트")
+    void testGetSaleRank() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        List<SaleRankingDto> sales = List.of(
+                SaleRankingDto.builder()
+                        .saleId(1)
+                        .title("sale1")
+                        .minPrice(10000)
+                        .orderCount(10L)
+                        .build(),
+                SaleRankingDto.builder()
+                        .saleId(2)
+                        .title("sale2")
+                        .minPrice(20000)
+                        .orderCount(20L)
+                        .build()
+        );
+        Page<SaleRankingDto> saleRanks = new PageImpl<>(sales, pageable, 2);
+        when(saleRepository.findTop50ByOrderCount(pageable)).thenReturn(saleRanks);
+
+        // when
+        PageResponseDto<SaleRankingDto> result = saleService.getTop50Sales(pageable);
+
+        // then
+        assertThat(result.getContents().size()).isEqualTo(2);
+        assertThat(result.getPageSize()).isEqualTo(10);
+        assertThat(result.getCurrentPage()).isEqualTo(0);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getTotalElements()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
@@ -28,6 +30,7 @@ import com.farmdora.farmdora.sale.repository.OptionRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -62,6 +65,9 @@ class SaleServiceTest {
 
     @Mock
     private QuestionRepository questionRepository;
+
+    @Mock
+    private SaleRedisService saleRedisService;
 
     @InjectMocks
     private SaleService saleService;
@@ -291,9 +297,12 @@ class SaleServiceTest {
     }
 
     @Test
-    @DisplayName("상품의 랭킹 정보 조회 서비스 레이어 테스트")
-    void testGetSaleRank() {
+    @DisplayName("상품의 랭킹 정보 DB 조회 서비스 레이어 테스트")
+    void testGetSaleRankByDB() {
         // given
+        when(saleRedisService.findSaleRanks(anyInt())).thenReturn(null);
+        when(saleRedisService.findSaleRankCount()).thenReturn(null);
+
         Pageable pageable = PageRequest.of(0, 10);
         List<SaleRankingDto> sales = List.of(
                 SaleRankingDto.builder()
@@ -321,5 +330,23 @@ class SaleServiceTest {
         assertThat(result.getCurrentPage()).isEqualTo(0);
         assertThat(result.getTotalPages()).isEqualTo(1);
         assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("상품의 랭킹 정보 캐시 조회 서비스 레이어 테스트")
+    void testGetSaleRankByCache() {
+        // given
+        List<SaleRankingDto> saleRanks = new ArrayList<>();
+        saleRanks.add(new SaleRankingDto());
+        when(saleRedisService.findSaleRanks(anyInt())).thenReturn(saleRanks);
+        when(saleRedisService.findSaleRankCount()).thenReturn(1);
+
+        // when
+        Pageable pageable = PageRequest.of(0, 10);
+        PageResponseDto<SaleRankingDto> result = saleService.getTop50Sales(pageable);
+
+        // then
+        verify(saleRepository, times(0)).findTop50ByOrderCount(pageable);
+        assertThat(result.getContents().size()).isEqualTo(1);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,6 +5,11 @@ spring:
     username: sa
     password:
 
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+
   jpa:
     show-sql: true
     properties:


### PR DESCRIPTION
## 📌 작업 내용
- [x] 인기상품목록 조회 API 구현
- [x] 테스트 케이스 작성
- [x] 인기상품목록 캐싱 및 스케쥴링 활성화

<br>

## 💡 필수확인 1. 인기상품목록 캐싱
메인화면의 인기상품목록은 가장 많이 조회되는 API이고 전체 상품을 기준으로 조회하는 만큼 시간도 오래걸립니다.
따라서 Redis에 10분마다 목록을 캐싱하여 조회 속도를 개선하였습니다.
`SaleRedisService` 클래스에 스케쥴링을 설정하여 10분마다 DB에서 조회해 캐시 목록을 업데이트하도록 설정하였습니다. 

## 💡 필수확인 2. API

### API Url
`GET` `/sale/rank`

### 파라미터
`page`: 페이지 번호

### 응답 데이터
페이지당 인기 상품 10개씩 조회
```json
{
    "status": 200,
    "message": "상품 랭킹 정보 조회에 성공하였습니다.",
    "data": {
        "currentPage": 0,
        "pageSize": 10,
        "totalElements": 1000000,
        "totalPages": 100000,
        "hasNext": true,
        "hasPrevious": false,
        "contents": [
            {
                "saleId": 1000000,
                "title": "상품1000000",
                "minPrice": 7640,
                "orderCount": 1
            },
            {
                "saleId": 999999,
                "title": "상품0999999",
                "minPrice": 6608,
                "orderCount": 1
            }
        ]
    }
}
```

<br><br>
## 📆 작업기간
2025.04.21 ~ 2024.04.22

<br>

## 📷 스크린샷(선택)

<br><br>
## ✅ 참고 사항(선택)