### PR TITLE
[FDORA-20] feat: 카테고리의 상품 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -12,7 +12,8 @@ public enum SuccessMessage {
     SEARCH_QUESTION_SUCCESS("문의 목록 조회에 성공하였습니다."),
     SEARCH_REVIEWS_SUCCESS("리뷰 목록 조회에 성공하였습니다."),
     GET_RELATED_SALES_SUCCESS("관련 상품 목록 조회에 성공하였습니다."),
-    GET_SALES_RANK("상품 랭킹 정보 조회에 성공하였습니다.");
+    GET_SALES_RANK("상품 랭킹 정보 조회에 성공하였습니다."),
+    GET_SALES_BY_CATEGORIES("카테고리의 상품 목록 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/farmdora/farmdora/entity/Like.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Like.java
@@ -2,9 +2,12 @@ package com.farmdora.farmdora.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,8 +29,12 @@ public class Like {
     @Column(name = "like_id")
     private Integer id;
 
-    private Integer saleId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sale_id")
+    private Sale sale;
 
-    private Integer userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 }
 

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALES_BY_CATEGORIES;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALES_RANK;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
@@ -13,6 +14,8 @@ import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
+import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.service.SaleService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -71,5 +75,16 @@ public class SaleController {
         PageResponseDto<SaleRankingDto> sales = saleService.getTop50Sales(pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALES_RANK.getMessage(), sales));
+    }
+
+    @GetMapping("/type")
+    public ResponseEntity<?> getSalesByType(@RequestParam Short bigTypeId,
+                                            @RequestParam Short typeId,
+                                            @RequestParam SaleSortType sort,
+                                            @PageableDefault(size = 20) Pageable pageable) {
+        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        PageResponseDto<SaleSummaryDto> sales = saleService.getSalesByCategory(1, bigTypeId, typeId, sort, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, GET_SALES_BY_CATEGORIES.getMessage(), sales));
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleSortType.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleSortType.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.sale.dto;
+
+public enum SaleSortType {
+    ORDER_DESC, ORDER_ASC, REVIEW_DESC, PRICE_ASC, PRICE_DESC, RECOMMEND
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleSummaryDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleSummaryDto.java
@@ -1,0 +1,26 @@
+package com.farmdora.farmdora.sale.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+public class SaleSummaryDto {
+    private Integer saleId;
+    private String title;
+    private Integer minPrice;
+    private boolean isLiked;
+    private String mainImage;
+
+    @QueryProjection
+    public SaleSummaryDto(Integer saleId, String title, Integer minPrice, boolean isLiked, String mainImage) {
+        this.saleId = saleId;
+        this.title = title;
+        this.minPrice = minPrice;
+        this.isLiked = isLiked;
+        this.mainImage = mainImage;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepository.java
@@ -1,13 +1,10 @@
 package com.farmdora.farmdora.sale.repository;
 
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
-import java.util.List;
+import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomSaleRepository {
-    Page<SaleDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable);
-    List<SaleOrderCountDto> searchSaleOrderCount(List<Integer> saleIds);
+    Page<SaleSummaryDto> searchSalesByCategories(Integer userId, Short bigTypeId, Short typeId, SaleSortType sortType, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/CustomSellerSaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/CustomSellerSaleRepository.java
@@ -1,0 +1,13 @@
+package com.farmdora.farmdora.sale.repository;
+
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomSellerSaleRepository {
+    Page<SaleDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable);
+    List<SaleOrderCountDto> searchSaleOrderCount(List<Integer> saleIds);
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/LikeRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/LikeRepository.java
@@ -4,5 +4,5 @@ import com.farmdora.farmdora.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
-    boolean existsByUserIdAndSaleId(Integer userId, Integer saleId);
+    boolean existsByUserUserIdAndSaleId(Integer userId, Integer saleId);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface SaleRepository extends JpaRepository<Sale, Integer>, CustomSaleRepository {
+public interface SaleRepository extends JpaRepository<Sale, Integer>, CustomSellerSaleRepository, CustomSaleRepository {
 
     @Query("SELECT new com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto(s.id, s.title, MIN(o.price), AVG(r.score), COUNT(r)) " +
             "FROM Sale s " +

--- a/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
@@ -1,31 +1,27 @@
 package com.farmdora.farmdora.sale.repository.impl;
 
+import static com.farmdora.farmdora.entity.QLike.like;
 import static com.farmdora.farmdora.entity.QOption.option;
 import static com.farmdora.farmdora.entity.QOrderOption.orderOption;
+import static com.farmdora.farmdora.entity.QReview.review;
 import static com.farmdora.farmdora.entity.QSale.sale;
-import static com.farmdora.farmdora.entity.QSaleType.saleType;
-import static com.farmdora.farmdora.entity.QSaleTypeBig.saleTypeBig;
+import static com.farmdora.farmdora.entity.QSaleFile.saleFile;
 
-import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleStatus;
-import com.farmdora.farmdora.sale.dto.querydsl.QSaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.QSaleOrderCountDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.sale.dto.QSaleSummaryDto;
+import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.repository.CustomSaleRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
-import org.springframework.util.StringUtils;
 
 @Slf4j
 public class CustomSaleRepositoryImpl implements CustomSaleRepository {
@@ -37,115 +33,61 @@ public class CustomSaleRepositoryImpl implements CustomSaleRepository {
     }
 
     @Override
-    public Page<SaleDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
-        List<SaleDto> sales = queryFactory
-                .select(
-                        new QSaleDto(sale.id, sale.title, sale.isBlind, option.price.min(), option.quantity.sum())
-                )
+    public Page<SaleSummaryDto> searchSalesByCategories(Integer userId, Short bigTypeId, Short typeId,
+                                                        SaleSortType sortType, Pageable pageable) {
+        List<SaleSummaryDto> sales = queryFactory
+                .select(new QSaleSummaryDto(
+                        sale.id,
+                        sale.title,
+                        option.price.min(),
+                        JPAExpressions
+                                .selectOne()
+                                .from(like)
+                                .where(like.sale.eq(sale)
+                                        .and(like.user.userId.eq(userId)))
+                                .exists(),
+                        saleFile.saveFile.max()))
                 .from(sale)
-                .join(option).on(option.sale.eq(sale))
-                .join(saleType).on(sale.type.eq(saleType))
-                .join(saleTypeBig).on(saleType.saleTypeBig.eq(saleTypeBig))
-                .where(
-                        sale.seller.id.eq(sellerId),
-                        titleContains(searchCondition.getKeyword()),
-                        isBlindEq(searchCondition.getFilters()),
-                        isSmallTypeEq(searchCondition.getTypeId()),
-                        isBigTypeEq(searchCondition.getTypeBigId())
-                )
-                .groupBy(sale.id, sale.title, sale.isBlind, sale.createdDate)
-                .orderBy(
-                        salesCreatedDateOrderBy(searchCondition.getSort()),
-                        salesIdOrderBy(searchCondition.getSort())
-                )
-                .limit(pageable.getPageSize())
+                .leftJoin(option).on(option.sale.eq(sale))
+                .leftJoin(orderOption).on(orderOption.option.eq(option))
+                .leftJoin(review).on(review.sale.eq(sale))
+                .leftJoin(saleFile).on(saleFile.sale.eq(sale).and(saleFile.isMain.isTrue()))
+                .leftJoin(like).on(like.sale.eq(sale))
+                .where(categoryCondition(typeId, bigTypeId))
+                .groupBy(sale.id, sale.title)
+                .orderBy(getSaleOrderSpecifier(sortType), sale.id.desc())
                 .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
-        JPAQuery<Long> countQuery = createCountQuery(sellerId, searchCondition);
+        log.info("카테고리 상품 목록: {}", sales);
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(sale.count())
+                .from(sale)
+                .where(categoryCondition(typeId, bigTypeId));
 
         return PageableExecutionUtils.getPage(sales, pageable, countQuery::fetchOne);
     }
 
-    @Override
-    public List<SaleOrderCountDto> searchSaleOrderCount(List<Integer> saleIds) {
-        return queryFactory
-                .select(new QSaleOrderCountDto(sale.id, orderOption.id.count()))
-                .from(orderOption)
-                .join(option).on(option.id.eq(orderOption.option.id))
-                .where(sale.id.in(saleIds))
-                .groupBy(sale.id)
-                .fetch();
-    }
-
-    private JPAQuery<Long> createCountQuery(Integer sellerId, SaleSearchRequestDto searchCondition) {
-        return queryFactory
-                .select(sale.countDistinct())
-                .from(sale)
-                .join(option).on(option.sale.eq(sale))
-                .join(saleType).on(sale.type.eq(saleType))
-                .join(saleTypeBig).on(saleType.saleTypeBig.eq(saleTypeBig))
-                .where(
-                        sale.seller.id.eq(sellerId),
-                        titleContains(searchCondition.getKeyword()),
-                        isBlindEq(searchCondition.getFilters()),
-                        isSmallTypeEq(searchCondition.getTypeId()),
-                        isBigTypeEq(searchCondition.getTypeBigId())
-                );
-    }
-
-    private BooleanExpression titleContains(String keyword) {
-        if (StringUtils.hasText(keyword)) {
-            return sale.title.contains(keyword);
-        }
-        return null;
-    }
-
-    private BooleanExpression isBlindEq(Set<SaleStatus> filters) {
-        if (filters == null || filters.isEmpty()) {
-            return null;
-        }
-
-        boolean hasInstock = filters.contains(SaleStatus.INSTOCK);
-        boolean hasPreorder = filters.contains(SaleStatus.PREORDER);
-
-        if (hasPreorder && hasInstock) {
-            return null;
-        } else if (hasPreorder) {
-            return sale.isBlind.isTrue();
-        } else if (hasInstock) {
-            return sale.isBlind.isFalse();
-        }
-        return null;
-    }
-
-    private BooleanExpression isSmallTypeEq(Short typeId) {
+    private BooleanExpression categoryCondition(Short typeId, Short bigTypeId) {
         if (typeId != null) {
             return sale.type.id.eq(typeId);
+        } else if (bigTypeId != null) {
+            return sale.type.saleTypeBig.id.eq(bigTypeId);
         }
         return null;
     }
 
-    private BooleanExpression isBigTypeEq(Short typeBigId) {
-        if (typeBigId != null) {
-            return sale.type.saleTypeBig.id.eq(typeBigId);
-        }
-        return null;
-    }
-
-    private OrderSpecifier<?> salesCreatedDateOrderBy(Sort sort) {
-        if (sort.equals(Sort.OLDEST)) {
-            return sale.createdDate.asc();
-        } else {
-            return sale.createdDate.desc();
-        }
-    }
-
-    private OrderSpecifier<?> salesIdOrderBy(Sort sort) {
-        if (sort.equals(Sort.OLDEST)) {
-            return sale.id.asc();
-        } else {
-            return sale.id.desc();
-        }
+    private OrderSpecifier<?> getSaleOrderSpecifier(SaleSortType sort) {
+        return switch (sort) {
+            case ORDER_DESC -> orderOption.id.count().desc();
+            case ORDER_ASC -> orderOption.id.count().asc();
+            case REVIEW_DESC -> review.id.count().desc();
+            case PRICE_ASC -> option.price.min().asc();
+            case PRICE_DESC -> option.price.min().desc();
+            case RECOMMEND -> like.id.count().desc();
+            default -> sale.id.desc();
+        };
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSellerSaleRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSellerSaleRepositoryImpl.java
@@ -1,0 +1,151 @@
+package com.farmdora.farmdora.sale.repository.impl;
+
+import static com.farmdora.farmdora.entity.QOption.option;
+import static com.farmdora.farmdora.entity.QOrderOption.orderOption;
+import static com.farmdora.farmdora.entity.QSale.sale;
+import static com.farmdora.farmdora.entity.QSaleType.saleType;
+import static com.farmdora.farmdora.entity.QSaleTypeBig.saleTypeBig;
+
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.QSaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.QSaleOrderCountDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import com.farmdora.farmdora.sale.repository.CustomSellerSaleRepository;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class CustomSellerSaleRepositoryImpl implements CustomSellerSaleRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CustomSellerSaleRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<SaleDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
+        List<SaleDto> sales = queryFactory
+                .select(
+                        new QSaleDto(sale.id, sale.title, sale.isBlind, option.price.min(), option.quantity.sum())
+                )
+                .from(sale)
+                .join(option).on(option.sale.eq(sale))
+                .join(saleType).on(sale.type.eq(saleType))
+                .join(saleTypeBig).on(saleType.saleTypeBig.eq(saleTypeBig))
+                .where(
+                        sale.seller.id.eq(sellerId),
+                        titleContains(searchCondition.getKeyword()),
+                        isBlindEq(searchCondition.getFilters()),
+                        isSmallTypeEq(searchCondition.getTypeId()),
+                        isBigTypeEq(searchCondition.getTypeBigId())
+                )
+                .groupBy(sale.id, sale.title, sale.isBlind, sale.createdDate)
+                .orderBy(
+                        salesCreatedDateOrderBy(searchCondition.getSort()),
+                        salesIdOrderBy(searchCondition.getSort())
+                )
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        JPAQuery<Long> countQuery = createCountQuery(sellerId, searchCondition);
+
+        return PageableExecutionUtils.getPage(sales, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public List<SaleOrderCountDto> searchSaleOrderCount(List<Integer> saleIds) {
+        return queryFactory
+                .select(new QSaleOrderCountDto(sale.id, orderOption.id.count()))
+                .from(orderOption)
+                .join(option).on(option.id.eq(orderOption.option.id))
+                .where(sale.id.in(saleIds))
+                .groupBy(sale.id)
+                .fetch();
+    }
+
+    private JPAQuery<Long> createCountQuery(Integer sellerId, SaleSearchRequestDto searchCondition) {
+        return queryFactory
+                .select(sale.countDistinct())
+                .from(sale)
+                .join(option).on(option.sale.eq(sale))
+                .join(saleType).on(sale.type.eq(saleType))
+                .join(saleTypeBig).on(saleType.saleTypeBig.eq(saleTypeBig))
+                .where(
+                        sale.seller.id.eq(sellerId),
+                        titleContains(searchCondition.getKeyword()),
+                        isBlindEq(searchCondition.getFilters()),
+                        isSmallTypeEq(searchCondition.getTypeId()),
+                        isBigTypeEq(searchCondition.getTypeBigId())
+                );
+    }
+
+    private BooleanExpression titleContains(String keyword) {
+        if (StringUtils.hasText(keyword)) {
+            return sale.title.contains(keyword);
+        }
+        return null;
+    }
+
+    private BooleanExpression isBlindEq(Set<SaleStatus> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return null;
+        }
+
+        boolean hasInstock = filters.contains(SaleStatus.INSTOCK);
+        boolean hasPreorder = filters.contains(SaleStatus.PREORDER);
+
+        if (hasPreorder && hasInstock) {
+            return null;
+        } else if (hasPreorder) {
+            return sale.isBlind.isTrue();
+        } else if (hasInstock) {
+            return sale.isBlind.isFalse();
+        }
+        return null;
+    }
+
+    private BooleanExpression isSmallTypeEq(Short typeId) {
+        if (typeId != null) {
+            return sale.type.id.eq(typeId);
+        }
+        return null;
+    }
+
+    private BooleanExpression isBigTypeEq(Short typeBigId) {
+        if (typeBigId != null) {
+            return sale.type.saleTypeBig.id.eq(typeBigId);
+        }
+        return null;
+    }
+
+    private OrderSpecifier<?> salesCreatedDateOrderBy(Sort sort) {
+        if (sort.equals(Sort.OLDEST)) {
+            return sale.createdDate.asc();
+        } else {
+            return sale.createdDate.desc();
+        }
+    }
+
+    private OrderSpecifier<?> salesIdOrderBy(Sort sort) {
+        if (sort.equals(Sort.OLDEST)) {
+            return sale.id.asc();
+        } else {
+            return sale.id.desc();
+        }
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -14,6 +14,8 @@ import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
+import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
@@ -60,7 +62,7 @@ public class SaleService {
             return SaleDetailDto.createSaleDetail(sale, saleImages, options, false);
         }
 
-        boolean exists = likeRepository.existsByUserIdAndSaleId(userId, saleId);
+        boolean exists = likeRepository.existsByUserUserIdAndSaleId(userId, saleId);
 
         return SaleDetailDto.createSaleDetail(sale, saleImages, options, exists);
     }
@@ -81,7 +83,7 @@ public class SaleService {
     private List<SaleRelatedDto> getRelatedSalesMainImageAndIsLike(Integer userId, List<SaleRelatedInfoDto> relatedSaleDetails) {
         List<SaleRelatedDto> relatedSales = new ArrayList<>();
         for (SaleRelatedInfoDto relatedSale : relatedSaleDetails) {
-            boolean isLike = likeRepository.existsByUserIdAndSaleId(userId, relatedSale.getSaleId());
+            boolean isLike = likeRepository.existsByUserUserIdAndSaleId(userId, relatedSale.getSaleId());
             Optional<SaleFile> saleFile = saleFileRepository.findBySaleIdAndIsMainIsTrue(relatedSale.getSaleId());
             relatedSales.add(SaleRelatedDto.createSaleRelatedDto(relatedSale, getMainImage(saleFile), isLike));
         }
@@ -134,6 +136,12 @@ public class SaleService {
 
     private PageResponseDto<SaleRankingDto> getTop50SalesFromDb(Pageable pageable) {
         Page<SaleRankingDto> sales = saleRepository.findTop50ByOrderCount(pageable);
+        return new PageResponseDto<>(sales.getContent(), sales);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<SaleSummaryDto> getSalesByCategory(Integer userId, Short bigTypeId, Short typeId, SaleSortType sortType, Pageable pageable) {
+        Page<SaleSummaryDto> sales = saleRepository.searchSalesByCategories(userId, bigTypeId, typeId, sortType, pageable);
         return new PageResponseDto<>(sales.getContent(), sales);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdora.sale.controller;
 
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_RELATED_SALES_SUCCESS;
+import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALES_BY_CATEGORIES;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALES_RANK;
 import static com.farmdora.farmdora.common.response.SuccessMessage.GET_SALE_DETAIL_SUCCESS;
 import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_QUESTION_SUCCESS;
@@ -8,6 +9,7 @@ import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEW
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -22,6 +24,8 @@ import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
+import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -234,5 +238,29 @@ public class SaleControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.data.hasNext", equalTo(false)))
                 .andExpect(jsonPath("$.data.currentPage", equalTo(0)))
                 .andExpect(jsonPath("$.data.totalElements", equalTo(100)));
+    }
+
+    @Test
+    @DisplayName("카테고리의 상품 목록 조회 API 테스트")
+    void testGetSalesByType() throws Exception {
+        // given
+        PageResponseDto<SaleSummaryDto> sales = new PageResponseDto<>();
+        sales.setPageSize(10);
+        sales.setHasPrevious(false);
+        sales.setHasNext(false);
+        sales.setCurrentPage(0);
+        sales.setPageSize(10);
+        sales.setTotalElements(100L);
+        when(saleService.getSalesByCategory(anyInt(), anyShort(), anyShort(), any(SaleSortType.class), any(Pageable.class))).thenReturn(sales);
+
+        // when
+        // then
+        mvc.perform(get("/sale/type")
+                        .param("bigTypeId", "2")
+                        .param("typeId", "6")
+                        .param("sort", "RECOMMEND"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(GET_SALES_BY_CATEGORIES.getMessage())));
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
@@ -2,36 +2,28 @@ package com.farmdora.farmdora.sale.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Like;
 import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.Order;
 import com.farmdora.farmdora.entity.OrderOption;
+import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.entity.SaleTypeBig;
-import com.farmdora.farmdora.entity.Seller;
-import com.farmdora.farmdora.order.dto.Sort;
-import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
-import com.farmdora.farmdora.sale.dto.SaleStatus;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
-import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.BeforeEach;
+import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Transactional
-@Import(AuditConfig.class)
 class CustomSaleRepositoryTest {
 
     @Autowired
@@ -40,97 +32,107 @@ class CustomSaleRepositoryTest {
     @Autowired
     private TestEntityManager em;
 
-    private Seller seller;
-    private SaleTypeBig bigType;
-    private SaleType smallType;
+    @Test
+    @DisplayName("카테고리에 해당하는 상품 조회 QueryDsl 테스트")
+    void testSearchSalesByCategories() {
+        // given
+        User user1 = new User();
+        User user2 = new User();
+        em.persist(user1);
+        em.persist(user2);
 
-    @BeforeEach
-    void setUp() {
-        seller = new Seller();
-        em.persist(seller);
-
-        bigType = SaleTypeBig.builder()
+        SaleTypeBig bigType = SaleTypeBig.builder()
                 .id((short) 1)
-                .name("과일")
                 .build();
         em.persist(bigType);
 
-        smallType = SaleType.builder()
+        SaleType type = SaleType.builder()
                 .id((short) 1)
-                .name("사과")
                 .saleTypeBig(bigType)
                 .build();
-        em.persist(smallType);
+        em.persist(type);
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 1; i <= 10; i++) {
             Sale sale = Sale.builder()
-                    .title("상추" + (i + 1))
-                    .isBlind(false)
-                    .seller(seller)
-                    .type(smallType)
+                    .title("Sale" + i)
+                    .type(type)
                     .build();
             em.persist(sale);
 
-            Option option1 = Option.builder()
-                    .price(100 * (i + 1))
-                    .quantity(100)
+            if (i % 2 != 0) {
+                Review review = Review.builder()
+                        .sale(sale)
+                        .build();
+                em.persist(review);
+            }
+
+            SaleFile saleFile1 = SaleFile.builder()
+                    .saveFile("saleFile1")
                     .sale(sale)
+                    .isMain(false)
+                    .build();
+            SaleFile saleFile2 = SaleFile.builder()
+                    .saveFile("saleFile2")
+                    .sale(sale)
+                    .isMain(true)
+                    .build();
+            em.persist(saleFile1);
+            em.persist(saleFile2);
+
+            Order order1 = new Order();
+            Order order2 = new Order();
+            em.persist(order1);
+            em.persist(order2);
+
+            Option option1 = Option.builder()
+                    .sale(sale)
+                    .price(1000 * i)
                     .build();
             Option option2 = Option.builder()
-                    .price(100 * (i + 1))
-                    .quantity(100)
                     .sale(sale)
+                    .price(2000 * i)
                     .build();
             em.persist(option1);
             em.persist(option2);
 
             OrderOption orderOption1 = OrderOption.builder()
+                    .order(order1)
                     .option(option1)
                     .build();
-            OrderOption orderOption2 = OrderOption.builder()
-                    .option(option2)
-                    .build();
             em.persist(orderOption1);
-            em.persist(orderOption2);
+
+            // 짝수번이 주문수가 가장 많음
+            if (i % 2 == 0) {
+                OrderOption orderOption2 = OrderOption.builder()
+                        .order(order2)
+                        .option(option2)
+                        .build();
+                em.persist(orderOption2);
+            }
+
+            // 짝수번이 좋아요수가 가장 많음
+            if (i % 2 == 0) {
+                em.persist(Like.builder()
+                        .sale(sale)
+                        .user(user1)
+                        .build());
+            }
         }
-    }
 
-    @Test
-    @DisplayName("상품 목록 검색 및 조회 테스트")
-    void testSearchSales() {
-        // given
-        Integer sellerId = seller.getId();
-        System.out.println(sellerId);
-        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
-                .keyword("상추")
-                .sort(Sort.LATEST)
-                .filters(Set.of(SaleStatus.INSTOCK))
-                .typeBigId(bigType.getId())
-                .typeId(smallType.getId())
-                .build();
+        em.flush();
+        em.clear();
+
+        // when
         Pageable pageable = PageRequest.of(0, 10);
-
-        // when
-        Page<SaleDto> result = saleRepository.searchSales(sellerId, searchCondition, pageable);
-
-        // then
-        assertThat(result.getContent().size()).isEqualTo(10);
-        assertThat(result.getTotalPages()).isEqualTo(1);
-        assertThat(result.getNumber()).isEqualTo(0);
-        assertThat(result.getTotalElements()).isEqualTo(10);
-    }
-
-    @Test
-    @DisplayName("상품 목록 주문 수 조회 테스트")
-    void testSearchOrderCounts() {
-        // given
-        List<Sale> sales = saleRepository.findAll();
-        List<Integer> saleIds = sales.stream().map(s -> s.getId()).collect(Collectors.toList());
-
-        // when
-        List<SaleOrderCountDto> orderCounts = saleRepository.searchSaleOrderCount(saleIds);
+        Page<SaleSummaryDto> salesByType = saleRepository.searchSalesByCategories(user1.getUserId(), bigType.getId(), type.getId(), SaleSortType.PRICE_DESC, pageable);
+        Page<SaleSummaryDto> salesByBigType = saleRepository.searchSalesByCategories(user1.getUserId(), bigType.getId(), null, SaleSortType.ORDER_DESC, pageable);
+        Page<SaleSummaryDto> salesByNoType = saleRepository.searchSalesByCategories(user1.getUserId(),null, null, SaleSortType.REVIEW_DESC, pageable);
+        Page<SaleSummaryDto> salesByLikeCount = saleRepository.searchSalesByCategories(user1.getUserId(),null, null, SaleSortType.RECOMMEND, pageable);
 
         // then
-        assertThat(orderCounts.size()).isEqualTo(10);
+        assertThat(salesByType.getContent().size()).isEqualTo(10);
+        assertThat(salesByBigType.getContent().size()).isEqualTo(10);
+        assertThat(salesByNoType.getContent().size()).isEqualTo(10);
+        assertThat(salesByLikeCount.getContent().size()).isEqualTo(10);
     }
 }

--- a/src/test/java/com/farmdora/farmdora/sale/repository/CustomSellerSaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/CustomSellerSaleRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.farmdora.farmdora.sale.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.config.AuditConfig;
+import com.farmdora.farmdora.entity.Option;
+import com.farmdora.farmdora.entity.OrderOption;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.SaleType;
+import com.farmdora.farmdora.entity.SaleTypeBig;
+import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
+import com.farmdora.farmdora.sale.dto.SaleStatus;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleDto;
+import com.farmdora.farmdora.sale.dto.querydsl.SaleOrderCountDto;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Transactional
+@Import(AuditConfig.class)
+class CustomSellerSaleRepositoryTest {
+
+    @Autowired
+    private SaleRepository saleRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private Seller seller;
+    private SaleTypeBig bigType;
+    private SaleType smallType;
+
+    @BeforeEach
+    void setUp() {
+        seller = new Seller();
+        em.persist(seller);
+
+        bigType = SaleTypeBig.builder()
+                .id((short) 1)
+                .name("과일")
+                .build();
+        em.persist(bigType);
+
+        smallType = SaleType.builder()
+                .id((short) 1)
+                .name("사과")
+                .saleTypeBig(bigType)
+                .build();
+        em.persist(smallType);
+
+        for (int i = 0; i < 10; i++) {
+            Sale sale = Sale.builder()
+                    .title("상추" + (i + 1))
+                    .isBlind(false)
+                    .seller(seller)
+                    .type(smallType)
+                    .build();
+            em.persist(sale);
+
+            Option option1 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .sale(sale)
+                    .build();
+            Option option2 = Option.builder()
+                    .price(100 * (i + 1))
+                    .quantity(100)
+                    .sale(sale)
+                    .build();
+            em.persist(option1);
+            em.persist(option2);
+
+            OrderOption orderOption1 = OrderOption.builder()
+                    .option(option1)
+                    .build();
+            OrderOption orderOption2 = OrderOption.builder()
+                    .option(option2)
+                    .build();
+            em.persist(orderOption1);
+            em.persist(orderOption2);
+        }
+    }
+
+    @Test
+    @DisplayName("상품 목록 검색 및 조회 테스트")
+    void testSearchSales() {
+        // given
+        Integer sellerId = seller.getId();
+        System.out.println(sellerId);
+        SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
+                .keyword("상추")
+                .sort(Sort.LATEST)
+                .filters(Set.of(SaleStatus.INSTOCK))
+                .typeBigId(bigType.getId())
+                .typeId(smallType.getId())
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<SaleDto> result = saleRepository.searchSales(sellerId, searchCondition, pageable);
+
+        // then
+        assertThat(result.getContent().size()).isEqualTo(10);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.getTotalElements()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("상품 목록 주문 수 조회 테스트")
+    void testSearchOrderCounts() {
+        // given
+        List<Sale> sales = saleRepository.findAll();
+        List<Integer> saleIds = sales.stream().map(s -> s.getId()).collect(Collectors.toList());
+
+        // when
+        List<SaleOrderCountDto> orderCounts = saleRepository.searchSaleOrderCount(saleIds);
+
+        // then
+        assertThat(orderCounts.size()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/sale/repository/LikeRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/LikeRepositoryTest.java
@@ -3,6 +3,8 @@ package com.farmdora.farmdora.sale.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.farmdora.farmdora.entity.Like;
+import com.farmdora.farmdora.entity.Sale;
+import com.farmdora.farmdora.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,16 +21,22 @@ class LikeRepositoryTest {
     private LikeRepository likeRepository;
 
     @Test
-    @DisplayName("existsByUserIdAndSaleId 쿼리 메서드 테스트")
+    @DisplayName("existsByUserIdAndSaleId() 쿼리 메서드 테스트")
     void testExistsByUserIdAndSaleId() {
         // given
+        User user = new User();
+        em.persist(user);
+
+        Sale sale = new Sale();
+        em.persist(sale);
+
         Like like1 = Like.builder()
-                .userId(1)
-                .saleId(1)
+                .user(user)
+                .sale(sale)
                 .build();
         Like like2 = Like.builder()
-                .userId(2)
-                .saleId(1)
+                .user(user)
+                .sale(sale)
                 .build();
         em.persist(like1);
         em.persist(like2);
@@ -37,7 +45,7 @@ class LikeRepositoryTest {
         em.clear();
 
         // when
-        boolean like = likeRepository.existsByUserIdAndSaleId(1, 1);
+        boolean like = likeRepository.existsByUserUserIdAndSaleId(user.getUserId(), sale.getId());
 
         // then
         assertThat(like).isEqualTo(true);

--- a/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/SaleRepositoryTest.java
@@ -69,8 +69,8 @@ class SaleRepositoryTest {
                 em.persist(review2);
             } else {
                 Like like = Like.builder()
-                        .saleId(sale.getId())
-                        .userId(user.getUserId())
+                        .sale(sale)
+                        .user(user)
                         .build();
                 em.persist(like);
 

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +26,8 @@ import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
+import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
@@ -116,7 +119,7 @@ class SaleServiceTest {
             );
             when(saleFileRepository.findAllBySale(any(Sale.class))).thenReturn(saleFiles);
 
-            when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
+            when(likeRepository.existsByUserUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
 
             // when
             SaleDetailDto saleDetail = saleService.getSaleDetail(1, 1);
@@ -172,7 +175,7 @@ class SaleServiceTest {
             );
             when(saleRepository.findTop10SalesWithReviewCountByTypeAndExcludedId(any(SaleType.class), anyInt(), any(Pageable.class))).thenReturn(relatedSaleDetails);
 
-            when(likeRepository.existsByUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
+            when(likeRepository.existsByUserUserIdAndSaleId(anyInt(), anyInt())).thenReturn(true);
 
             SaleFile mockSaleFile = SaleFile.builder()
                     .sale(mockSale)
@@ -348,5 +351,37 @@ class SaleServiceTest {
         // then
         verify(saleRepository, times(0)).findTop50ByOrderCount(pageable);
         assertThat(result.getContents().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("특정 카테고리의 상품 목록 조회 서비스 레이어 테스트")
+    void testGetSalesByCategory() {
+        // given
+        List<SaleSummaryDto> saleSummaries = List.of(
+                SaleSummaryDto.builder()
+                        .saleId(1)
+                        .title("sale1")
+                        .minPrice(10000)
+                        .isLiked(false)
+                        .build(),
+                SaleSummaryDto.builder()
+                        .saleId(2)
+                        .title("sale2")
+                        .minPrice(20000)
+                        .isLiked(false)
+                        .build()
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+        PageImpl<SaleSummaryDto> sales = new PageImpl<>(saleSummaries, pageable, 2);
+        when(saleRepository.searchSalesByCategories(anyInt(), anyShort(), anyShort(), any(SaleSortType.class), any(Pageable.class))).thenReturn(sales);
+
+        // when
+        Short bigTypeId = 1;
+        Short typeId = 2;
+        PageResponseDto<SaleSummaryDto> result = saleService.getSalesByCategory(1, bigTypeId, typeId, SaleSortType.PRICE_DESC, pageable);
+
+        // then
+        assertThat(result.getContents().size()).isEqualTo(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
- [x] 카테고리의 상품 목록 조회 API 구현
- [x] 테스트 케이스 작성
- [x] Like 엔티티 수정
- [x] 판매자 관련 조회 메서드, 구매자 관련 조회 메서드 클래스로 분리

<br>

## 💡 필수확인 1. API 요청

### API URL
`GET` `/sale/type`

### 파라미터
`page`: 페이지 번호(0부터 시작)
`typeId`: 소분류 카테고리 아이디
`bigTypeId`: 대분류 카테고리 아이디

### 응답 데이터
페이지마다 20개씩 조회.
페이지 사이즈를 수정하고 싶은 경우 size를 파라미터로 전달.
```json
{
    "status": 200,
    "message": "카테고리의 상품 목록 조회에 성공하였습니다.",
    "data": {
        "currentPage": 49999,
        "pageSize": 20,
        "totalElements": 1000000,
        "totalPages": 50000,
        "hasNext": false,
        "hasPrevious": true,
        "contents": [
            {
                "saleId": 21,
                "title": "상품0000021",
                "minPrice": 4421,
                "mainImage": null,
                "liked": false
            },
            {
                "saleId": 20,
                "title": "상품0000020",
                "minPrice": 4215,
                "mainImage": null,
                "liked": false
            }
        ]
    }
}
```


<br>

## 📆 작업기간
2025.04.22 ~ 2025.04.23

<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)
