### PR TITLE
[FDORA-146] feat: 관리자 사용자 목록 검색 API 구현

### DIFF
--- a/src/main/java/com/farmdora/farmdora/admin/controller/UserController.java
+++ b/src/main/java/com/farmdora/farmdora/admin/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.farmdora.farmdora.admin.controller;
+
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_USERS_SUCCESS;
+
+import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
+import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
+import com.farmdora.farmdora.admin.service.UserService;
+import com.farmdora.farmdora.common.response.HttpResponse;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<?> searchUsers(UserSearchRequestDto searchCondition,
+                                         @PageableDefault Pageable pageable) {
+        PageResponseDto<UserSearchResponseDto> users = userService.searchUsers(searchCondition, pageable);
+        return ResponseEntity.ok()
+                .body(new HttpResponse(HttpStatus.OK, SEARCH_USERS_SUCCESS.getMessage(), users));
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchRequestDto.java
@@ -1,5 +1,6 @@
 package com.farmdora.farmdora.admin.dto;
 
+import com.farmdora.farmdora.order.dto.Sort;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,4 +18,5 @@ import lombok.ToString;
 public class UserSearchRequestDto {
     private String keyword;
     private List<UserType> types;
+    private Sort sort;
 }

--- a/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchRequestDto.java
@@ -1,0 +1,20 @@
+package com.farmdora.farmdora.admin.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSearchRequestDto {
+    private String keyword;
+    private List<UserType> types;
+}

--- a/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchResponseDto.java
@@ -1,0 +1,28 @@
+package com.farmdora.farmdora.admin.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+public class UserSearchResponseDto {
+    private Integer userId;
+    private String name;
+    private Boolean isBlind;
+    private Boolean isSeller;
+
+    @QueryProjection
+    public UserSearchResponseDto(Integer userId, String name, Boolean isBlind, Boolean isSeller) {
+        this.userId = userId;
+        this.name = name;
+        this.isBlind = isBlind;
+        this.isSeller = isSeller;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/admin/dto/UserType.java
+++ b/src/main/java/com/farmdora/farmdora/admin/dto/UserType.java
@@ -1,0 +1,5 @@
+package com.farmdora.farmdora.admin.dto;
+
+public enum UserType {
+    USER, SELLER
+}

--- a/src/main/java/com/farmdora/farmdora/admin/repository/CustomUserRepository.java
+++ b/src/main/java/com/farmdora/farmdora/admin/repository/CustomUserRepository.java
@@ -1,0 +1,10 @@
+package com.farmdora.farmdora.admin.repository;
+
+import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
+import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomUserRepository {
+    Page<UserSearchResponseDto> searchUsers(UserSearchRequestDto searchCondition, Pageable pageable);
+}

--- a/src/main/java/com/farmdora/farmdora/admin/repository/UserRepository.java
+++ b/src/main/java/com/farmdora/farmdora/admin/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.farmdora.farmdora.admin.repository;
+
+import com.farmdora.farmdora.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Integer>, CustomUserRepository {
+}

--- a/src/main/java/com/farmdora/farmdora/admin/repository/impl/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/admin/repository/impl/CustomUserRepositoryImpl.java
@@ -1,0 +1,82 @@
+package com.farmdora.farmdora.admin.repository.impl;
+
+import static com.farmdora.farmdora.entity.QSeller.seller;
+import static com.farmdora.farmdora.entity.QUser.user;
+
+import com.farmdora.farmdora.admin.dto.QUserSearchResponseDto;
+import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
+import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
+import com.farmdora.farmdora.admin.dto.UserType;
+import com.farmdora.farmdora.admin.repository.CustomUserRepository;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+public class CustomUserRepositoryImpl implements CustomUserRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CustomUserRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<UserSearchResponseDto> searchUsers(UserSearchRequestDto searchCondition, Pageable pageable) {
+        List<UserSearchResponseDto> users = queryFactory
+                .select(new QUserSearchResponseDto(
+                        user.userId,
+                        user.name,
+                        user.isBlind,
+                        seller.id.isNotNull()
+                ))
+                .from(user)
+                .leftJoin(seller).on(seller.user.eq(user))
+                .where(
+                        nameContains(searchCondition.getKeyword()),
+                        roleTypeCondition(searchCondition.getTypes())
+                )
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(user.count())
+                .from(user)
+                .leftJoin(seller).on(seller.user.eq(user))
+                .where(
+                        nameContains(searchCondition.getKeyword()),
+                        roleTypeCondition(searchCondition.getTypes())
+                );
+
+        return PageableExecutionUtils.getPage(users, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression nameContains(String name) {
+        if (StringUtils.hasText(name)) {
+            return user.name.contains(name);
+        }
+        return null;
+    }
+
+    private BooleanExpression roleTypeCondition(List<UserType> types) {
+        if (types != null && !types.isEmpty()) {
+            boolean hasUser = types.contains(UserType.USER);
+            boolean hasSeller = types.contains(UserType.SELLER);
+
+            if (hasUser && hasSeller) {
+                return null;
+            } else if (hasUser) {
+                return seller.id.isNull();
+            } else if (hasSeller) {
+                return seller.id.isNotNull();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/admin/repository/impl/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/admin/repository/impl/CustomUserRepositoryImpl.java
@@ -8,6 +8,8 @@ import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
 import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
 import com.farmdora.farmdora.admin.dto.UserType;
 import com.farmdora.farmdora.admin.repository.CustomUserRepository;
+import com.farmdora.farmdora.order.dto.Sort;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -43,6 +45,7 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 )
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
+                .orderBy(usersOrderBy(searchCondition.getSort()), user.userId.desc())
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
@@ -78,5 +81,16 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
             }
         }
         return null;
+    }
+
+    private OrderSpecifier<?> usersOrderBy(Sort sort) {
+        if (sort != null) {
+            return switch (sort) {
+                case LATEST -> user.createdDate.desc();
+                case OLDEST -> user.createdDate.asc();
+                default -> null;
+            };
+        }
+        return user.createdDate.desc();
     }
 }

--- a/src/main/java/com/farmdora/farmdora/admin/service/UserService.java
+++ b/src/main/java/com/farmdora/farmdora/admin/service/UserService.java
@@ -1,0 +1,25 @@
+package com.farmdora.farmdora.admin.service;
+
+import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
+import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
+import com.farmdora.farmdora.admin.repository.UserRepository;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public PageResponseDto<UserSearchResponseDto> searchUsers(UserSearchRequestDto searchCondition, Pageable pageable) {
+        Page<UserSearchResponseDto> users = userRepository.searchUsers(searchCondition, pageable);
+        return new PageResponseDto<>(users.getContent(), users);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
+++ b/src/main/java/com/farmdora/farmdora/common/response/SuccessMessage.java
@@ -12,7 +12,8 @@ public enum SuccessMessage {
     SEARCH_QUESTION_SUCCESS("문의 목록 조회에 성공하였습니다."),
     SEARCH_REVIEWS_SUCCESS("리뷰 목록 조회에 성공하였습니다."),
     GET_RELATED_SALES_SUCCESS("관련 상품 목록 조회에 성공하였습니다."),
-    GET_SALES_RANK("상품 랭킹 정보 조회에 성공하였습니다.");
+    GET_SALES_RANK("상품 랭킹 정보 조회에 성공하였습니다."),
+    SEARCH_USERS_SUCCESS("사용자 목록 조회에 성공하였습니다.");
 
     private final String message;
 }

--- a/src/test/java/com/farmdora/farmdora/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/ControllerTest.java
@@ -1,5 +1,7 @@
 package com.farmdora.farmdora;
 
+import com.farmdora.farmdora.admin.controller.UserController;
+import com.farmdora.farmdora.admin.service.UserService;
 import com.farmdora.farmdora.order.controller.OrderController;
 import com.farmdora.farmdora.order.service.OrderService;
 import com.farmdora.farmdora.opinion.controller.OpinionController;
@@ -18,7 +20,8 @@ import org.springframework.test.web.servlet.MockMvc;
         SaleController.class,
         OpinionController.class,
         SellerSaleController.class,
-        SaleController.class
+        SaleController.class,
+        UserController.class
 })
 public abstract class ControllerTest {
 
@@ -36,4 +39,7 @@ public abstract class ControllerTest {
 
     @MockitoBean
     protected OpinionService opinionService;
+
+    @MockitoBean
+    protected UserService userService;
 }

--- a/src/test/java/com/farmdora/farmdora/admin/controller/UserControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/admin/controller/UserControllerTest.java
@@ -1,0 +1,55 @@
+package com.farmdora.farmdora.admin.controller;
+
+import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_USERS_SUCCESS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.farmdora.farmdora.ControllerTest;
+import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
+import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+
+class UserControllerTest extends ControllerTest {
+
+    @Test
+    @DisplayName("관리자의 사용자 목록 검색 API 테스트")
+    void testSearchUsers() throws Exception {
+        // given
+        List<UserSearchResponseDto> users = List.of(
+                UserSearchResponseDto.builder()
+                        .userId(1)
+                        .isBlind(true)
+                        .name("user1")
+                        .isSeller(false)
+                        .build(),
+                UserSearchResponseDto.builder()
+                        .userId(2)
+                        .isBlind(true)
+                        .name("user2")
+                        .isSeller(true)
+                        .build()
+        );
+        PageResponseDto<UserSearchResponseDto> pageResult = new PageResponseDto<>();
+        pageResult.setContents(users);
+        pageResult.setTotalElements(2L);
+        when(userService.searchUsers(any(UserSearchRequestDto.class), any(Pageable.class))).thenReturn(pageResult);
+
+        // when
+        // then
+        mvc.perform(get("/admin/user")
+                .param("keyword", "user")
+                .param("types", "USER"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(SEARCH_USERS_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.data.contents.size()", equalTo(2)));
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/admin/repository/CustomUserRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/admin/repository/CustomUserRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.farmdora.farmdora.admin.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
+import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
+import com.farmdora.farmdora.admin.dto.UserType;
+import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.entity.User;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+class CustomUserRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("관리자 사용자 검색 QueryDsl 테스트")
+    void testSearchUsers() {
+        // given
+        for (int i = 1; i <= 15; i++) {
+            User user = User.builder()
+                    .name("user" + i)
+                    .isBlind(false)
+                    .build();
+            em.persist(user);
+
+            if (i % 2 == 0) {
+                Seller seller = Seller.builder()
+                        .user(user)
+                        .build();
+                em.persist(seller);
+            }
+        }
+
+        // when
+        UserSearchRequestDto searchSellerCondition = UserSearchRequestDto.builder()
+                .keyword("user")
+                .types(List.of(UserType.SELLER))
+                .build();
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<UserSearchResponseDto> sellers = userRepository.searchUsers(searchSellerCondition, pageable);
+
+        UserSearchRequestDto searchUserCondition = UserSearchRequestDto.builder()
+                .keyword("user")
+                .types(List.of(UserType.USER))
+                .build();
+        Page<UserSearchResponseDto> users = userRepository.searchUsers(searchUserCondition, pageable);
+
+        UserSearchRequestDto searchAllCondition = UserSearchRequestDto.builder()
+                .keyword("user")
+                .types(List.of(UserType.USER, UserType.SELLER))
+                .build();
+        Page<UserSearchResponseDto> allUsers = userRepository.searchUsers(searchAllCondition, pageable);
+
+        // then
+        assertThat(sellers.getContent().size()).isEqualTo(7);
+        assertThat(sellers.getContent().get(0).getIsSeller()).isEqualTo(true);
+        assertThat(users.getContent().size()).isEqualTo(8);
+        assertThat(users.getContent().get(0).getIsSeller()).isEqualTo(false);
+        assertThat(allUsers.getContent().size()).isEqualTo(10);
+        assertThat(allUsers.getTotalElements()).isEqualTo(15);
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/admin/service/UserServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/admin/service/UserServiceTest.java
@@ -1,0 +1,65 @@
+package com.farmdora.farmdora.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.farmdora.farmdora.admin.dto.UserSearchRequestDto;
+import com.farmdora.farmdora.admin.dto.UserSearchResponseDto;
+import com.farmdora.farmdora.admin.dto.UserType;
+import com.farmdora.farmdora.admin.repository.UserRepository;
+import com.farmdora.farmdora.common.response.PageResponseDto;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("사용자 목록 검색 서비스 레이어 테스트")
+    void testSearchUsers() {
+        // given
+        List<UserSearchResponseDto> users = List.of(
+                UserSearchResponseDto.builder()
+                        .userId(1)
+                        .isBlind(true)
+                        .name("user1")
+                        .isSeller(false)
+                        .build(),
+                UserSearchResponseDto.builder()
+                        .userId(2)
+                        .isBlind(true)
+                        .name("user2")
+                        .isSeller(true)
+                        .build()
+        );
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<UserSearchResponseDto> userPage = new PageImpl<>(users, pageable, 2);
+        when(userRepository.searchUsers(any(UserSearchRequestDto.class), any(Pageable.class))).thenReturn(userPage);
+
+        // when
+        UserSearchRequestDto searchCondition = UserSearchRequestDto.builder()
+                .keyword("user")
+                .types(List.of(UserType.USER))
+                .build();
+        PageResponseDto<UserSearchResponseDto> result = userService.searchUsers(searchCondition, pageable);
+
+        // then
+        assertThat(result.getContents().size()).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- [x] 관리자의 사용자 목록 검색 API 구현
- [x] 사용자 목록 검색 테스트 케이스 추가

<br>

## 💡 필수확인
### API URL
`GET` `/admin/user`

### 요청 파라미터
`keyword` : 회원명
`types` : 구매자/판매자 (`USER`/`SELLER`)
`sort` : 정렬조건 (`LATEST`/`OLDEST`)

구매자/판매자 모두 조회하고 싶은 경우 `&types=USER&types=SELLER` 와같이 배열로 전달

### 응답 데이터
```json
{
    "status": 200,
    "message": "사용자 목록 조회에 성공하였습니다.",
    "data": {
        "currentPage": 0,
        "pageSize": 10,
        "totalElements": 4,
        "totalPages": 1,
        "hasNext": false,
        "hasPrevious": false,
        "contents": [
            {
                "userId": 1,
                "name": "홍길동",
                "isBlind": false,
                "isSeller": true
            },
            {
                "userId": 2,
                "name": "김철수",
                "isBlind": false,
                "isSeller": true
            }
        ]
    }
}
```

<br>

## 📆 작업기간
2025.04.26

<br>

## 📷 스크린샷(선택)

<br>

## ✅ 참고 사항(선택)