### PR TITLE
[FDORA-154] feat: 시큐리티 적용 및 QueryDsl 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     // database
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // querydsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -48,7 +49,12 @@ dependencies {
     // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/farmdora/farmdora/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/farmdora/farmdora/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.farmdora.farmdora.auth;
+
+import static com.farmdora.farmdora.auth.JwtConstants.*;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = request.getHeader(AUTHORIZATION_HEADER);
+        if (token != null) {
+            token = token.replace(TOKEN_PREFIX, "");
+        }
+
+        if (token != null && jwtUtil.validateToken(token)) {
+            int userId = jwtUtil.getUserId(token);
+
+            if (Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_KEY + token))) {
+                log.warn("블랙리스트 토큰 접근 차단");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, jwtUtil.getAuthorities(token));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/JwtConstants.java
+++ b/src/main/java/com/farmdora/farmdora/auth/JwtConstants.java
@@ -1,0 +1,7 @@
+package com.farmdora.farmdora.auth;
+
+public interface JwtConstants {
+    String AUTHORIZATION_HEADER = "Authorization";
+    String TOKEN_PREFIX = "Bearer ";
+    String BLACKLIST_KEY = "blacklist:";
+}

--- a/src/main/java/com/farmdora/farmdora/auth/JwtUtil.java
+++ b/src/main/java/com/farmdora/farmdora/auth/JwtUtil.java
@@ -1,0 +1,61 @@
+package com.farmdora.farmdora.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS512.key()
+                        .build()
+                        .getAlgorithm());
+    }
+
+    public Integer getUserId(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload().get("userId", Integer.class);
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities(String token) {
+        String role = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    public boolean validateToken(String token) {
+        try{
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token).getPayload();
+            return !claims.getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Jwt 요효성 검사 실패: {}" , e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/auth/config/SecurityConfig.java
+++ b/src/main/java/com/farmdora/farmdora/auth/config/SecurityConfig.java
@@ -1,0 +1,70 @@
+package com.farmdora.farmdora.auth.config;
+
+import com.farmdora.farmdora.auth.JwtAuthenticationFilter;
+import com.farmdora.farmdora.auth.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((auth)->
+                        auth
+                                .requestMatchers("/admin/**").hasRole("ADMIN")
+                                .requestMatchers("/my/seller/**").hasRole("SELLER")
+                                .anyRequest().permitAll())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, redisTemplate), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement((session)-> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/farmdora/farmdora/common/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package com.farmdora.farmdora.common.exception;
 
 import com.farmdora.farmdora.common.response.HttpResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -20,6 +22,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<?> customExceptionHandler(IllegalArgumentException e) {
+        log.error(e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new HttpResponse(HttpStatus.INTERNAL_SERVER_ERROR, ILLEGAL_ERROR_MESSAGE, null));

--- a/src/main/java/com/farmdora/farmdora/config/JasyptConfig.java
+++ b/src/main/java/com/farmdora/farmdora/config/JasyptConfig.java
@@ -1,0 +1,34 @@
+package com.farmdora.farmdora.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class JasyptConfig {
+
+    @Value("${jasypt.encryptor.password}")
+    private String password;
+
+    @Bean("jasyptEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(password);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("1");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+
+        return encryptor;
+    }
+}

--- a/src/main/java/com/farmdora/farmdora/entity/Review.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Review.java
@@ -38,5 +38,7 @@ public class Review extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    private String reply;
+
     private byte score;
 }

--- a/src/main/java/com/farmdora/farmdora/entity/ReviewFile.java
+++ b/src/main/java/com/farmdora/farmdora/entity/ReviewFile.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.BatchSize;
 
 @Getter
 @Builder
@@ -20,6 +21,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@BatchSize(size = 100)
 public class ReviewFile {
 
     @Id

--- a/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/controller/OpinionController.java
@@ -9,6 +9,7 @@ import com.farmdora.farmdora.opinion.dto.QuestionResponseDto;
 import com.farmdora.farmdora.opinion.dto.OpinionSearchRequestDto;
 import com.farmdora.farmdora.opinion.dto.ReviewResponseDto;
 import com.farmdora.farmdora.opinion.service.OpinionService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -27,18 +28,21 @@ public class OpinionController {
     private final OpinionService opinionService;
 
     @GetMapping("/inquiry")
-    public ResponseEntity<?> searchQuestions(Integer sellerId,
+    public ResponseEntity<?> searchQuestions(Principal principal,
                                              OpinionSearchRequestDto searchCondition,
                                              @PageableDefault Pageable pageable) {
-        PageResponseDto<QuestionResponseDto> questions = opinionService.searchQuestions(sellerId, searchCondition, pageable);
+        String userId = principal.getName();
+        PageResponseDto<QuestionResponseDto> questions = opinionService.searchQuestions(Integer.parseInt(userId), searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_QUESTION_SUCCESS.getMessage(), questions));
     }
 
     @GetMapping("/review")
-    public ResponseEntity<?> searchReviews(OpinionSearchRequestDto searchCondition,
+    public ResponseEntity<?> searchReviews(Principal principal,
+                                           OpinionSearchRequestDto searchCondition,
                                            @PageableDefault Pageable pageable) {
-        PageResponseDto<ReviewResponseDto> reviews = opinionService.searchReviews(searchCondition, pageable);
+        String userId = principal.getName();
+        PageResponseDto<ReviewResponseDto> reviews = opinionService.searchReviews(Integer.parseInt(userId), searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_REVIEWS_SUCCESS.getMessage(), reviews));
     }

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/OpinionSearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/OpinionSearchRequestDto.java
@@ -17,7 +17,6 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OpinionSearchRequestDto {
-    private Integer sellerId;  // TODO JWT 구현완료 후 제거 예정
     private SearchType searchType;
     private String keyword;
     private SearchPeriod searchPeriod;

--- a/src/main/java/com/farmdora/farmdora/opinion/dto/ReviewResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/dto/ReviewResponseDto.java
@@ -14,6 +14,7 @@ public class ReviewResponseDto {
     private String saleTitle;
     private String reviewContent;
     private String writer;
+    private String reply;
     private LocalDateTime createdDate;
     private byte score;
 
@@ -22,12 +23,14 @@ public class ReviewResponseDto {
                              String saleTitle,
                              String reviewContent,
                              String writer,
+                             String reply,
                              LocalDateTime createdDate,
                              byte score) {
         this.reviewId = reviewId;
         this.saleTitle = saleTitle;
         this.reviewContent = reviewContent;
         this.writer = writer;
+        this.reply = reply;
         this.createdDate = createdDate;
         this.score = score;
     }

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/CustomReviewRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/CustomReviewRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomReviewRepository {
-    Page<ReviewResponseDto> searchReviews(OpinionSearchRequestDto searchCondition, Pageable pageable);
+    Page<ReviewResponseDto> searchReviews(Integer userId, OpinionSearchRequestDto searchCondition, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/QuestionRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/QuestionRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface QuestionRepository extends JpaRepository<Question, Integer>, CustomQuestionRepository {
 
-    @Query("SELECT new com.farmdora.farmdora.sale.dto.QuestionResponseDto(q.id, q.title, u.name, q.isProcess, q.createdDate) "
+    @Query("SELECT new com.farmdora.farmdora.sale.dto.QuestionResponseDto(q.id, q.title, u.name, q.content, q.answer, q.isProcess, q.createdDate) "
             + "FROM Question q JOIN q.user u "
             + "WHERE q.sale = :sale")
     Page<QuestionResponseDto> findQuestionsBySaleId(@Param("sale")Sale sale, Pageable pageable);

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/ReviewRepository.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/ReviewRepository.java
@@ -4,8 +4,10 @@ import com.farmdora.farmdora.entity.Review;
 import com.farmdora.farmdora.entity.Sale;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Integer>, CustomReviewRepository {
+    @EntityGraph(attributePaths = {"order.user"})
     Page<Review> findAllBySale(Sale sale, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
@@ -2,8 +2,9 @@ package com.farmdora.farmdora.opinion.repository.impl;
 
 import static com.farmdora.farmdora.entity.QQuestion.question;
 import static com.farmdora.farmdora.entity.QSale.sale;
-import static com.farmdora.farmdora.entity.QUser.user;
+import static com.farmdora.farmdora.entity.QSeller.seller;
 
+import com.farmdora.farmdora.entity.QUser;
 import com.farmdora.farmdora.order.dto.SearchPeriod;
 import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
@@ -34,7 +36,7 @@ public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
     }
 
     @Override
-    public Page<QuestionResponseDto> searchQuestions(Integer sellerId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
+    public Page<QuestionResponseDto> searchQuestions(Integer userId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
         List<QuestionResponseDto> questions = queryFactory
                 .select(new QQuestionResponseDto(
                         question.id,
@@ -46,7 +48,7 @@ public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
                 ))
                 .from(question)
                 .where(
-                        sale.seller.id.eq(sellerId),
+                        sale.seller.user.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
                         dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(),
                                 searchCondition.getSearchPeriod()),
@@ -58,14 +60,18 @@ public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
                 .fetch();
 
         log.info("문의 목록: {}", questions);
+        QUser sellerUser = new QUser("sellerUser");
+        QUser buyer = new QUser("buyer");
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(question.count())
                 .from(question)
-                .join(user).on(question.user.eq(user))
-                .join(sale).on(question.sale.eq(sale))
+                .join(question.sale, sale)
+                .join(question.user, sellerUser)
+                .join(sale.seller, seller)
+                .join(seller.user, buyer)
                 .where(
-                        question.sale.seller.id.eq(sellerId),
+                        sellerUser.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
                         dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(),
                                 searchCondition.getSearchPeriod()),
@@ -76,7 +82,7 @@ public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
     }
 
     private BooleanExpression keywordContains(SearchType searchType, String keyword) {
-        if (searchType != null && keyword != null) {
+        if (searchType != null && StringUtils.hasText(keyword)) {
             if (searchType.equals(SearchType.PRODUCT)) {
                 return sale.title.contains(keyword);
             } else if (searchType.equals(SearchType.BUYER)){

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomReviewRepositoryImpl.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 public class CustomReviewRepositoryImpl implements CustomReviewRepository {
@@ -34,7 +35,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     }
 
     @Override
-    public Page<ReviewResponseDto> searchReviews(OpinionSearchRequestDto searchCondition, Pageable pageable) {
+    public Page<ReviewResponseDto> searchReviews(Integer userId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
         List<ReviewResponseDto> reviews = queryFactory
                 .select(
                         new QReviewResponseDto(review.id, sale.title, review.content, user.name, review.createdDate, review.score)
@@ -44,7 +45,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
                 .join(order).on(review.order.eq(order))
                 .join(user).on(order.user.eq(user))
                 .where(
-                        sale.seller.id.eq(searchCondition.getSellerId()),
+                        sale.seller.user.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
                         dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(),
                                 searchCondition.getSearchPeriod())
@@ -63,7 +64,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
                 .join(order).on(review.order.eq(order))
                 .join(user).on(order.user.eq(user))
                 .where(
-                        sale.seller.id.eq(searchCondition.getSellerId()),
+                        sale.seller.user.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
                         dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(), searchCondition.getSearchPeriod())
                 );
@@ -74,7 +75,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     }
 
     private BooleanExpression keywordContains(SearchType searchType, String keyword) {
-        if (searchType != null && keyword != null) {
+        if (searchType != null && StringUtils.hasText(keyword)) {
             if (searchType.equals(SearchType.PRODUCT)) {
                 return sale.title.contains(keyword);
             } else if (searchType.equals(SearchType.BUYER)){

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomReviewRepositoryImpl.java
@@ -38,7 +38,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     public Page<ReviewResponseDto> searchReviews(Integer userId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
         List<ReviewResponseDto> reviews = queryFactory
                 .select(
-                        new QReviewResponseDto(review.id, sale.title, review.content, user.name, review.createdDate, review.score)
+                        new QReviewResponseDto(review.id, sale.title, review.content, user.name, review.reply, review.createdDate, review.score)
                 )
                 .from(sale)
                 .join(review).on(review.sale.eq(sale))

--- a/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/service/OpinionService.java
@@ -20,14 +20,14 @@ public class OpinionService {
     private final ReviewRepository reviewRepository;
 
     @Transactional(readOnly = true)
-    public PageResponseDto<QuestionResponseDto> searchQuestions(Integer sellerId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
-        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(sellerId, searchCondition, pageable);
+    public PageResponseDto<QuestionResponseDto> searchQuestions(Integer userId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
+        Page<QuestionResponseDto> questions = questionRepository.searchQuestions(userId, searchCondition, pageable);
         return new PageResponseDto<>(questions.getContent(), questions);
     }
 
     @Transactional(readOnly = true)
-    public PageResponseDto<ReviewResponseDto> searchReviews(OpinionSearchRequestDto searchCondition, Pageable pageable) {
-        Page<ReviewResponseDto> reviews = reviewRepository.searchReviews(searchCondition, pageable);
+    public PageResponseDto<ReviewResponseDto> searchReviews(Integer userId, OpinionSearchRequestDto searchCondition, Pageable pageable) {
+        Page<ReviewResponseDto> reviews = reviewRepository.searchReviews(userId, searchCondition, pageable);
         return new PageResponseDto<>(reviews.getContent(), reviews);
     }
 }

--- a/src/main/java/com/farmdora/farmdora/order/controller/OrderController.java
+++ b/src/main/java/com/farmdora/farmdora/order/controller/OrderController.java
@@ -7,6 +7,7 @@ import com.farmdora.farmdora.order.dto.OrderSearchRequestDto;
 import com.farmdora.farmdora.order.dto.OrderSearchResponseDto;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.order.service.OrderService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -24,11 +25,11 @@ public class OrderController {
     private final OrderService orderService;
 
     @GetMapping("/search")
-    public ResponseEntity<?> searchOrders(Integer userId,
+    public ResponseEntity<?> searchOrders(Principal principal,
                                           OrderSearchRequestDto searchCondition,
                                           @PageableDefault Pageable pageable) {
-        // TODO 스프링 시큐리티 구현 후 userId 가져오기
-        PageResponseDto<OrderSearchResponseDto> orders = orderService.searchOrders(userId, searchCondition, pageable);
+        String userId = principal.getName();
+        PageResponseDto<OrderSearchResponseDto> orders = orderService.searchOrders(Integer.parseInt(userId), searchCondition, pageable);
         return ResponseEntity
                 .ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_ORDER_SUCCESS.getMessage(), orders));

--- a/src/main/java/com/farmdora/farmdora/order/repository/impl/CustomOrderRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/order/repository/impl/CustomOrderRepositoryImpl.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 public class CustomOrderRepositoryImpl implements CustomOrderRepository {
@@ -38,7 +39,7 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
     }
 
     @Override
-    public Page<OrderDto> searchOrders(Integer sellerId, OrderSearchRequestDto searchCondition, Pageable pageable) {
+    public Page<OrderDto> searchOrders(Integer userId, OrderSearchRequestDto searchCondition, Pageable pageable) {
         List<OrderDto> orders = queryFactory
                 .select(
                         new QOrderDto(order.id, user.name, orderStatus.name, orderOption.price.sum(), order.createdDate)
@@ -51,7 +52,7 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
                 .join(sale).on(option.sale.eq(sale))
                 .join(seller).on(sale.seller.eq(seller))
                 .where(
-                        seller.id.eq(sellerId),
+                        seller.user.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
                         statusIn(searchCondition.getStatusIds()),
                         dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(), searchCondition.getSearchPeriod())
@@ -72,7 +73,7 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
                 .join(option).on(orderOption.option.eq(option))
                 .join(sale).on(option.sale.eq(sale))
                 .where(
-                        seller.id.eq(sellerId),
+                        seller.user.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
                         statusIn(searchCondition.getStatusIds()),
                         dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(), searchCondition.getSearchPeriod())
@@ -85,7 +86,7 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
 
     @Override
     public List<OrderDetailDto> findOrderDetailsByIds(List<Integer> orderIds, Sort sort) {
-        List<OrderDetailDto> orderDetails = queryFactory
+        return queryFactory
                 .select(
                         new QOrderDetailDto(
                                 order.id,
@@ -102,9 +103,8 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
                 .join(sale).on(option.sale.eq(sale))
                 .where(order.id.in(orderIds))
                 .orderBy(ordersOrderBy(sort))
+                .groupBy(order.id, sale.id, sale.title, option.id, option.name, orderOption.quantity, orderOption.price)
                 .fetch();
-
-        return orderDetails;
     }
 
     private BooleanExpression statusIn(List<Short> statusIds) {
@@ -115,6 +115,10 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
     }
 
     private BooleanExpression keywordContains(SearchType searchType, String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return null;
+        }
+
         if (searchType.equals(SearchType.PRODUCT)) {
             return sale.title.contains(keyword);
         } else if (searchType.equals(SearchType.BUYER)){

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -17,6 +17,7 @@ import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.service.SaleService;
+import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -36,18 +37,18 @@ public class SaleController {
     private final SaleService saleService;
 
     @GetMapping("/{saleId}")
-    public ResponseEntity<?> getSaleDetail(Integer userId, @PathVariable("saleId") Integer saleId) {
-        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+    public ResponseEntity<?> getSaleDetail(Principal principal, @PathVariable("saleId") Integer saleId) {
+        Integer userId = Integer.parseInt(principal.getName());
         SaleDetailDto saleDetail = saleService.getSaleDetail(userId, saleId);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALE_DETAIL_SUCCESS.getMessage(), saleDetail));
     }
 
     @GetMapping("/related/{saleId}")
-    public ResponseEntity<?> getRelatedSales(Integer userId,
+    public ResponseEntity<?> getRelatedSales(Principal principal,
                                              @PathVariable("saleId") Integer saleId,
                                              @PageableDefault Pageable pageable) {
-        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+        Integer userId = Integer.parseInt(principal.getName());
         List<SaleRelatedDto> relatedSales = saleService.getRelatedSales(userId, saleId, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_RELATED_SALES_SUCCESS.getMessage(), relatedSales));
@@ -56,7 +57,6 @@ public class SaleController {
     @GetMapping("/review/{saleId}")
     public ResponseEntity<?> getSaleReviews(@PathVariable("saleId") Integer saleId,
                                             @PageableDefault Pageable pageable) {
-        // TODO 스프링 시큐리티 구현 후 userId 가져오기
         PageResponseDto<ReviewDetailDto> reviews = saleService.getSaleReviews(saleId, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_REVIEWS_SUCCESS.getMessage(), reviews));
@@ -78,12 +78,13 @@ public class SaleController {
     }
 
     @GetMapping("/type")
-    public ResponseEntity<?> getSalesByType(@RequestParam Short bigTypeId,
-                                            @RequestParam Short typeId,
-                                            @RequestParam SaleSortType sort,
+    public ResponseEntity<?> getSalesByType(Principal principal,
+                                            @RequestParam(required = false) Short bigTypeId,
+                                            @RequestParam(required = false) Short typeId,
+                                            @RequestParam(required = false) SaleSortType sort,
                                             @PageableDefault(size = 20) Pageable pageable) {
-        // TODO 스프링 시큐리티 구현 후 userId 가져오기
-        PageResponseDto<SaleSummaryDto> sales = saleService.getSalesByCategory(1, bigTypeId, typeId, sort, pageable);
+        Integer userId = Integer.parseInt(principal.getName());
+        PageResponseDto<SaleSummaryDto> sales = saleService.getSalesByCategory(userId, bigTypeId, typeId, sort, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALES_BY_CATEGORIES.getMessage(), sales));
     }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SellerSaleController.java
@@ -6,8 +6,8 @@ import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSearchResponseDto;
-import com.farmdora.farmdora.sale.service.SaleService;
 import com.farmdora.farmdora.sale.service.SellerSaleService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -27,21 +27,20 @@ public class SellerSaleController {
     private final SellerSaleService saleService;
 
     @PostMapping("/search")
-    public ResponseEntity<?> searchWithJson(@RequestBody SaleSearchRequestDto searchCondition) {
-        // TODO 스프링 시큐리티 구현 후 userId 가져오기
-        log.info("상품 목록 검색: {}", searchCondition);
+    public ResponseEntity<?> searchWithJson(Principal principal, @RequestBody SaleSearchRequestDto searchCondition) {
+        Integer userId = Integer.parseInt(principal.getName());
         Pageable pageable = searchCondition.toPageable();
-        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(searchCondition.getSellerId(), searchCondition, pageable);
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(userId, searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
     }
 
     @GetMapping("/search")
-    public ResponseEntity<?> searchWithParams() {
-        // TODO 스프링 시큐리티 구현 후 userId 가져오기
+    public ResponseEntity<?> searchWithParams(Principal principal) {
+        Integer userId = Integer.parseInt(principal.getName());
         SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder().build();
         Pageable pageable = searchCondition.toPageable();
-        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(1, searchCondition, pageable);
+        PageResponseDto<SaleSearchResponseDto> result = saleService.searchSales(userId, searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, SEARCH_SALES_SUCCESS.getMessage(), result));
     }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/QuestionResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/QuestionResponseDto.java
@@ -13,6 +13,8 @@ public class QuestionResponseDto {
     private Integer id;
     private String title;
     private String writer;
+    private String content;
+    private String answer;
     private boolean isProcess;
     private LocalDateTime createdDate;
 }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/ReviewDetailDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/ReviewDetailDto.java
@@ -1,29 +1,35 @@
 package com.farmdora.farmdora.sale.dto;
 
 import com.farmdora.farmdora.entity.Review;
+import com.farmdora.farmdora.entity.ReviewFile;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.*;
 
 @Getter
 @Setter
 @Builder
 @ToString
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 public class ReviewDetailDto {
     private Integer reviewId;
     private String writer;
     private String content;
     private Byte score;
     private LocalDateTime createdDate;
+    private List<String> reviewFiles;
 
-    public static ReviewDetailDto fromEntity(Review review) {
+    public static ReviewDetailDto fromEntity(Review review, List<ReviewFile> reviewFiles) {
         return ReviewDetailDto.builder()
                 .reviewId(review.getId())
                 .writer(review.getOrder().getUser().getName())
                 .content(review.getContent())
                 .score(review.getScore())
                 .createdDate(review.getCreatedDate())
+                .reviewFiles(reviewFiles.stream()
+                        .map(ReviewFile::getSaveFile)
+                        .toList())
                 .build();
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleDetailDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleDetailDto.java
@@ -21,6 +21,7 @@ public class SaleDetailDto {
 
     private List<OptionDetailDto> options;
 
+    private String title;
     private String origin;
     private boolean isLike;
     private String content;
@@ -35,8 +36,9 @@ public class SaleDetailDto {
 
         return SaleDetailDto.builder()
                 .files(images)
+                .title(sale.getTitle())
                 .origin(sale.getOrigin())
-                 .isLike(isLike)
+                .isLike(isLike)
                 .options(optionDetails)
                 .content(sale.getContent())
                 .build();

--- a/src/main/java/com/farmdora/farmdora/sale/repository/ReviewFileRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/ReviewFileRepository.java
@@ -1,0 +1,9 @@
+package com.farmdora.farmdora.sale.repository;
+
+import com.farmdora.farmdora.entity.ReviewFile;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewFileRepository extends JpaRepository<ReviewFile, Integer> {
+    List<ReviewFile> findByReviewIdIn(List<Integer> reviewIds);
+}

--- a/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
@@ -18,12 +18,10 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
-@Slf4j
 public class CustomSaleRepositoryImpl implements CustomSaleRepository {
 
     private final JPAQueryFactory queryFactory;
@@ -60,8 +58,6 @@ public class CustomSaleRepositoryImpl implements CustomSaleRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        log.info("카테고리 상품 목록: {}", sales);
-
         JPAQuery<Long> countQuery = queryFactory
                 .select(sale.count())
                 .from(sale)
@@ -71,9 +67,12 @@ public class CustomSaleRepositoryImpl implements CustomSaleRepository {
     }
 
     private BooleanExpression categoryCondition(Short typeId, Short bigTypeId) {
-        if (typeId != null) {
+        boolean hasType = typeId != null;
+        boolean hasBigType = bigTypeId != null;
+
+        if (hasType) {
             return sale.type.id.eq(typeId);
-        } else if (bigTypeId != null) {
+        } else if (hasBigType) {
             return sale.type.saleTypeBig.id.eq(bigTypeId);
         }
         return null;

--- a/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSellerSaleRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSellerSaleRepositoryImpl.java
@@ -37,7 +37,7 @@ public class CustomSellerSaleRepositoryImpl implements CustomSellerSaleRepositor
     }
 
     @Override
-    public Page<SaleDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
+    public Page<SaleDto> searchSales(Integer userId, SaleSearchRequestDto searchCondition, Pageable pageable) {
         List<SaleDto> sales = queryFactory
                 .select(
                         new QSaleDto(sale.id, sale.title, sale.isBlind, option.price.min(), option.quantity.sum())
@@ -47,7 +47,7 @@ public class CustomSellerSaleRepositoryImpl implements CustomSellerSaleRepositor
                 .join(saleType).on(sale.type.eq(saleType))
                 .join(saleTypeBig).on(saleType.saleTypeBig.eq(saleTypeBig))
                 .where(
-                        sale.seller.id.eq(sellerId),
+                        sale.seller.user.userId.eq(userId),
                         titleContains(searchCondition.getKeyword()),
                         isBlindEq(searchCondition.getFilters()),
                         isSmallTypeEq(searchCondition.getTypeId()),
@@ -62,7 +62,7 @@ public class CustomSellerSaleRepositoryImpl implements CustomSellerSaleRepositor
                 .offset(pageable.getOffset())
                 .fetch();
 
-        JPAQuery<Long> countQuery = createCountQuery(sellerId, searchCondition);
+        JPAQuery<Long> countQuery = createCountQuery(userId, searchCondition);
 
         return PageableExecutionUtils.getPage(sales, pageable, countQuery::fetchOne);
     }
@@ -78,7 +78,7 @@ public class CustomSellerSaleRepositoryImpl implements CustomSellerSaleRepositor
                 .fetch();
     }
 
-    private JPAQuery<Long> createCountQuery(Integer sellerId, SaleSearchRequestDto searchCondition) {
+    private JPAQuery<Long> createCountQuery(Integer userId, SaleSearchRequestDto searchCondition) {
         return queryFactory
                 .select(sale.countDistinct())
                 .from(sale)
@@ -86,7 +86,7 @@ public class CustomSellerSaleRepositoryImpl implements CustomSellerSaleRepositor
                 .join(saleType).on(sale.type.eq(saleType))
                 .join(saleTypeBig).on(saleType.saleTypeBig.eq(saleTypeBig))
                 .where(
-                        sale.seller.id.eq(sellerId),
+                        sale.seller.user.userId.eq(userId),
                         titleContains(searchCondition.getKeyword()),
                         isBlindEq(searchCondition.getFilters()),
                         isSmallTypeEq(searchCondition.getTypeId()),

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleRedisService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleRedisService.java
@@ -39,7 +39,6 @@ public class SaleRedisService {
         int total = content.size();
 
         for (int page = 0; page < (total + PAGE_SIZE - 1) / PAGE_SIZE; page++) {
-            log.info("실행중...");
             int start = page * PAGE_SIZE;
             int end = Math.min(start + PAGE_SIZE, total);
 

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -4,6 +4,7 @@ import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.entity.Option;
 import com.farmdora.farmdora.entity.Review;
+import com.farmdora.farmdora.entity.ReviewFile;
 import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.opinion.repository.QuestionRepository;
@@ -18,11 +19,14 @@ import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
+import com.farmdora.farmdora.sale.repository.ReviewFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,6 +48,7 @@ public class SaleService {
     private final ReviewRepository reviewRepository;
     private final QuestionRepository questionRepository;
     private final SaleRedisService saleRedisService;
+    private final ReviewFileRepository reviewFileRepository;
 
     @Value("${ncp.image.path}")
     private String imagePath;
@@ -56,7 +61,7 @@ public class SaleService {
         Sale sale = saleRepository.findById(saleId)
                 .orElseThrow(() -> new ResourceNotFoundException("Sale", saleId));
         List<Option> options = optionRepository.findAllBySale(sale);
-        List<SaleFile> saleImages = saleFileRepository.findAllBySale(sale);
+        List<SaleFile> saleImages = addImagePath(saleFileRepository.findAllBySale(sale));
 
         if (userId == null) {
             return SaleDetailDto.createSaleDetail(sale, saleImages, options, false);
@@ -65,6 +70,18 @@ public class SaleService {
         boolean exists = likeRepository.existsByUserUserIdAndSaleId(userId, saleId);
 
         return SaleDetailDto.createSaleDetail(sale, saleImages, options, exists);
+    }
+
+    private List<SaleFile> addImagePath(List<SaleFile> saleImages) {
+        return saleImages.stream()
+                .map(file -> SaleFile.builder()
+                        .id(file.getId())
+                        .saveFile(String.format("%s%s%s", imagePath, file.getSaveFile(), type))
+                        .sale(file.getSale())
+                        .isMain(file.isMain())
+                        .originFile(file.getOriginFile())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
@@ -104,10 +121,32 @@ public class SaleService {
                 .orElseThrow(() -> new ResourceNotFoundException("Sale", saleId));
 
         Page<Review> reviews = reviewRepository.findAllBySale(sale, pageable);
+
+        List<Integer> reviewIds = reviews.getContent()
+                .stream()
+                .map(Review::getId)
+                .toList();
+
+        List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewIdIn(reviewIds);
+
+        Map<Integer, List<ReviewFile>> reviewFileMap = reviewFiles.stream()
+                .collect(Collectors.groupingBy(rf -> rf.getReview().getId()));
+
         List<ReviewDetailDto> reviewDetails = reviews.getContent()
                 .stream()
-                .map(ReviewDetailDto::fromEntity)
+                .map(r -> ReviewDetailDto.fromEntity(
+                        r,
+                        reviewFileMap.getOrDefault(r.getId(), List.of())
+                                .stream()
+                                .map(f -> ReviewFile.builder()
+                                        .id(f.getId())
+                                        .saveFile(String.format("%s%s%s", imagePath, f.getSaveFile(), type))
+                                        .review(f.getReview())
+                                        .build()
+                                ).collect(Collectors.toList())
+                ))
                 .toList();
+
         return new PageResponseDto<>(reviewDetails, reviews);
     }
 
@@ -142,6 +181,13 @@ public class SaleService {
     @Transactional(readOnly = true)
     public PageResponseDto<SaleSummaryDto> getSalesByCategory(Integer userId, Short bigTypeId, Short typeId, SaleSortType sortType, Pageable pageable) {
         Page<SaleSummaryDto> sales = saleRepository.searchSalesByCategories(userId, bigTypeId, typeId, sortType, pageable);
+
+        sales.getContent().forEach(s -> {
+            if (s.getMainImage() != null) {
+                s.setMainImage(imagePath + s.getMainImage() + type);
+            }
+        });
+
         return new PageResponseDto<>(sales.getContent(), sales);
     }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/service/SellerSaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SellerSaleService.java
@@ -23,8 +23,8 @@ public class SellerSaleService {
     private final SaleMapper saleMapper;
 
     @Transactional(readOnly = true)
-    public PageResponseDto<SaleSearchResponseDto> searchSales(Integer sellerId, SaleSearchRequestDto searchCondition, Pageable pageable) {
-        Page<SaleDto> salePage = saleRepository.searchSales(sellerId, searchCondition, pageable);
+    public PageResponseDto<SaleSearchResponseDto> searchSales(Integer userId, SaleSearchRequestDto searchCondition, Pageable pageable) {
+        Page<SaleDto> salePage = saleRepository.searchSales(userId, searchCondition, pageable);
         List<SaleDto> sales = salePage.getContent();
         List<Integer> saleIds = getSaleIds(sales);
         List<SaleOrderCountDto> orderCounts = getOrderCounts(saleIds);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8030
+
 spring:
   profiles:
     active: local
@@ -5,6 +8,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+  jwt:
+    secret: ENC(AJv6LokZXWCLSDdDEFT1UGe19935JohjmPnbyDPFNQWa+WgVgEaBrsg3Fo8Xo8Myj3KHBd5e5Ka5pLS8nyOm2NNBdvwSAbjfBlpcZENOkyA=)
+
+jasypt:
+  encryptor:
+    password: ${key}
+    bean: jasyptEncryptor
 
 ncp:
   image:

--- a/src/test/java/com/farmdora/farmdora/ControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/ControllerTest.java
@@ -10,8 +10,11 @@ import com.farmdora.farmdora.sale.controller.SaleController;
 import com.farmdora.farmdora.sale.controller.SellerSaleController;
 import com.farmdora.farmdora.sale.service.SaleService;
 import com.farmdora.farmdora.sale.service.SellerSaleService;
+import com.farmdora.farmdora.security.TestSecurityConfig;
+import com.farmdora.farmdora.security.WithCustomMockUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -23,6 +26,8 @@ import org.springframework.test.web.servlet.MockMvc;
         SaleController.class,
         UserController.class
 })
+@WithCustomMockUser
+@Import({TestSecurityConfig.class})
 public abstract class ControllerTest {
 
     @Autowired

--- a/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/controller/OpinionControllerTest.java
@@ -92,7 +92,7 @@ class OpinionControllerTest extends ControllerTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<ReviewResponseDto> reviewPage = new PageImpl<>(reviews, pageable, 2);
         PageResponseDto<ReviewResponseDto> result = new PageResponseDto<>(reviews, reviewPage);
-        when(opinionService.searchReviews(any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
+        when(opinionService.searchReviews(anyInt(), any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(result);
 
         // when
         // then

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/CustomQuestionRepositoryTest.java
@@ -37,10 +37,11 @@ class CustomQuestionRepositoryTest {
     private QuestionRepository questionRepository;
 
     private Seller seller;
+    private User user;
 
     @BeforeEach
     void setUp() {
-        User user = User.builder()
+        user = User.builder()
                 .phoneNum("010-1234-5678")
                 .name("user")
                 .build();
@@ -48,6 +49,7 @@ class CustomQuestionRepositoryTest {
 
         seller = Seller.builder()
                 .name("seller")
+                .user(user)
                 .build();
         em.persist(seller);
 
@@ -74,7 +76,8 @@ class CustomQuestionRepositoryTest {
     @DisplayName("상품명으로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
     void testSearchQuestions() {
         // given
-        Integer sellerId = seller.getId();
+        Integer sellerId = user.getUserId();
+        System.out.println("ID: " + sellerId);
         OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
                 .searchType(SearchType.PRODUCT)
                 .keyword("상추")
@@ -100,7 +103,8 @@ class CustomQuestionRepositoryTest {
     @DisplayName("작성자명으로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
     void testSearchQuestionsByWriter() {
         // given
-        Integer sellerId = seller.getId();
+        Integer sellerId = user.getUserId();
+        System.out.println("ID: " + sellerId);
         OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
                 .searchType(SearchType.BUYER)
                 .keyword("user")
@@ -126,7 +130,8 @@ class CustomQuestionRepositoryTest {
     @DisplayName("SearchPeriod로 판매자의 문의 목록 조회 QueryDsl 실행 테스트")
     void testSearchQuestionsBySearchPeriod() {
         // given
-        Integer sellerId = seller.getId();
+        Integer sellerId = user.getUserId();
+        System.out.println("ID: " + sellerId);
         OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
                 .searchType(SearchType.BUYER)
                 .keyword("user")

--- a/src/test/java/com/farmdora/farmdora/opinion/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/repository/ReviewRepositoryTest.java
@@ -36,18 +36,20 @@ public class ReviewRepositoryTest {
     @DisplayName("판매자의 리뷰 목록 검색 QueryDsl 테스트")
     void testSearchReviews() {
         // given
-        Seller seller = new Seller();
+        User user = User.builder()
+                .name("user")
+                .build();
+        em.persist(user);
+
+        Seller seller = Seller.builder()
+                .user(user)
+                .build();
         em.persist(seller);
 
         Sale sale = Sale.builder()
                 .title("sale")
                 .build();
         em.persist(sale);
-
-        User user = User.builder()
-                .name("user")
-                .build();
-        em.persist(user);
 
         Order order = Order.builder()
                 .user(user)
@@ -65,13 +67,12 @@ public class ReviewRepositoryTest {
 
         // when
         OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
-                .sellerId(seller.getId())
                 .searchType(SearchType.PRODUCT)
                 .keyword("sale")
                 .searchPeriod(SearchPeriod.WEEK)
                 .build();
         Pageable pageable = PageRequest.of(0, 10);
-        Page<ReviewResponseDto> result = reviewRepository.searchReviews(searchCondition, pageable);
+        Page<ReviewResponseDto> result = reviewRepository.searchReviews(user.getUserId(), searchCondition, pageable);
 
         // then
         System.out.println(result.getContent());

--- a/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/opinion/service/OpinionServiceTest.java
@@ -104,7 +104,7 @@ class OpinionServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
         Page<ReviewResponseDto> reviewPage = new PageImpl<>(reviews, pageable, 2);
 
-        when(reviewRepository.searchReviews(any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(reviewPage);
+        when(reviewRepository.searchReviews(anyInt(), any(OpinionSearchRequestDto.class), any(Pageable.class))).thenReturn(reviewPage);
 
         // when
         OpinionSearchRequestDto searchCondition = OpinionSearchRequestDto.builder()
@@ -113,7 +113,7 @@ class OpinionServiceTest {
                 .searchPeriod(SearchPeriod.TODAY)
                 .sort(Sort.OLDEST)
                 .build();
-        PageResponseDto<ReviewResponseDto> result = opinionService.searchReviews(searchCondition, pageable);
+        PageResponseDto<ReviewResponseDto> result = opinionService.searchReviews(1, searchCondition, pageable);
 
         // then
         assertThat(result.getContents().size()).isEqualTo(2);

--- a/src/test/java/com/farmdora/farmdora/order/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/order/repository/OrderRepositoryTest.java
@@ -74,6 +74,7 @@ class OrderRepositoryTest {
 
         seller = Seller.builder()
                 .name("홍길동")
+                .user(user)
                 .build();
         em.persist(seller);
 

--- a/src/test/java/com/farmdora/farmdora/sale/repository/CustomSellerSaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/CustomSellerSaleRepositoryTest.java
@@ -9,6 +9,7 @@ import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.entity.SaleTypeBig;
 import com.farmdora.farmdora.entity.Seller;
+import com.farmdora.farmdora.entity.User;
 import com.farmdora.farmdora.order.dto.Sort;
 import com.farmdora.farmdora.sale.dto.SaleSearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleStatus;
@@ -46,7 +47,12 @@ class CustomSellerSaleRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        seller = new Seller();
+        User user = new User();
+        em.persist(user);
+
+        seller = Seller.builder()
+                .user(user)
+                .build();
         em.persist(seller);
 
         bigType = SaleTypeBig.builder()
@@ -99,7 +105,7 @@ class CustomSellerSaleRepositoryTest {
     @DisplayName("상품 목록 검색 및 조회 테스트")
     void testSearchSales() {
         // given
-        Integer sellerId = seller.getId();
+        Integer sellerId = seller.getUser().getUserId();
         System.out.println(sellerId);
         SaleSearchRequestDto searchCondition = SaleSearchRequestDto.builder()
                 .keyword("상추")

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
+import com.farmdora.farmdora.sale.repository.ReviewFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleFileRepository;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
 import java.time.LocalDateTime;
@@ -68,6 +70,9 @@ class SaleServiceTest {
 
     @Mock
     private QuestionRepository questionRepository;
+
+    @Mock
+    private ReviewFileRepository reviewFileRepository;
 
     @Mock
     private SaleRedisService saleRedisService;
@@ -241,6 +246,8 @@ class SaleServiceTest {
             Pageable pageable = PageRequest.of(0, 10);
             PageImpl<Review> reviewPages = new PageImpl<>(reviews, pageable, 2);
             when(reviewRepository.findAllBySale(any(Sale.class), any(Pageable.class))).thenReturn(reviewPages);
+
+            when(reviewFileRepository.findByReviewIdIn(anyList())).thenReturn(new ArrayList<>());
 
             // when
             PageResponseDto<ReviewDetailDto> result = saleService.getSaleReviews(1, pageable);

--- a/src/test/java/com/farmdora/farmdora/security/TestSecurityConfig.java
+++ b/src/test/java/com/farmdora/farmdora/security/TestSecurityConfig.java
@@ -1,0 +1,18 @@
+package com.farmdora.farmdora.security;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests.anyRequest().permitAll())
+                .build();
+    }
+}

--- a/src/test/java/com/farmdora/farmdora/security/WithCustomMockUser.java
+++ b/src/test/java/com/farmdora/farmdora/security/WithCustomMockUser.java
@@ -1,0 +1,12 @@
+package com.farmdora.farmdora.security;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+    String username() default "1";
+    String role() default "USER";
+}

--- a/src/test/java/com/farmdora/farmdora/security/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/farmdora/farmdora/security/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,23 @@
+package com.farmdora.farmdora.security;
+
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+        String username = annotation.username();
+        String role = annotation.role();
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(username, "password", List.of(new SimpleGrantedAuthority(role)));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        return context;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,6 +18,14 @@ spring:
         highlight_sql: true
         use_sql_comments: true
 
+  jwt:
+    secret: ENC(AJv6LokZXWCLSDdDEFT1UGe19935JohjmPnbyDPFNQWa+WgVgEaBrsg3Fo8Xo8Myj3KHBd5e5Ka5pLS8nyOm2NNBdvwSAbjfBlpcZENOkyA=)
+
+jasypt:
+  encryptor:
+    password: ${key}
+    bean: jasyptEncryptor
+
 ncp:
   image:
     path: https://zcbg41sa9729.edge.naverncp.com/O8XfcLSSm6/product/


### PR DESCRIPTION
## 📌 작업 내용
- [x] 시큐리티 적용
- [x] JWT 검증 필터 추가
- [x] 모든 컨트롤러에서 `Principal`객체로부터 `userId` 사용
- [x] Seller의 sellerId가 아닌 Seller.User.userId를 참조하도록 QueryDsl 수정
- [x] 카테고리 목록 조회시 typeId, bigTypeId 필수파라미터 해제

<br>

## 💡 필수확인 1. 시큐리티 적용
- 시큐리티 설정 파일 적용
- JWT 검증 필터 및 유틸 클래스 추가
- 컨트롤러에서는 Principal을 사용하여 사용자 아이디 추출(`CustomUserDetail`이 없으므로 `@AuthenticationPrincipal` 사용불가)

## 💡 필수확인 2. QueryDsl 수정
- 기존에 Seller.id를 참조하던 쿼리를 Seller.User.userId를 참조하도록 수정

<br>

## 📆 작업기간
2025.04.30
