### PR TITLE
[FDORA-157] feat: 인기상품목록 조회 및 관리자의 사용자 목록 검색 로직 수정

### DIFF
--- a/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchResponseDto.java
+++ b/src/main/java/com/farmdora/farmdora/admin/dto/UserSearchResponseDto.java
@@ -1,6 +1,7 @@
 package com.farmdora.farmdora.admin.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,15 +15,19 @@ import lombok.ToString;
 @NoArgsConstructor
 public class UserSearchResponseDto {
     private Integer userId;
+    private String id;
     private String name;
     private Boolean isBlind;
     private Boolean isSeller;
+    private LocalDateTime createdDate;
 
     @QueryProjection
-    public UserSearchResponseDto(Integer userId, String name, Boolean isBlind, Boolean isSeller) {
+    public UserSearchResponseDto(Integer userId, String id, String name, Boolean isBlind, Boolean isSeller, LocalDateTime createdDate) {
         this.userId = userId;
+        this.id = id;
         this.name = name;
         this.isBlind = isBlind;
         this.isSeller = isSeller;
+        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/farmdora/farmdora/admin/repository/impl/CustomUserRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/admin/repository/impl/CustomUserRepositoryImpl.java
@@ -33,10 +33,13 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
         List<UserSearchResponseDto> users = queryFactory
                 .select(new QUserSearchResponseDto(
                         user.userId,
+                        user.id,
                         user.name,
                         user.isBlind,
-                        seller.id.isNotNull()
+                        seller.id.isNotNull(),
+                        user.createdDate
                 ))
+                .distinct()
                 .from(user)
                 .leftJoin(seller).on(seller.user.eq(user))
                 .where(
@@ -49,7 +52,7 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
-                .select(user.count())
+                .select(user.userId.countDistinct())
                 .from(user)
                 .leftJoin(seller).on(seller.user.eq(user))
                 .where(

--- a/src/main/java/com/farmdora/farmdora/common/NcpImageProperties.java
+++ b/src/main/java/com/farmdora/farmdora/common/NcpImageProperties.java
@@ -12,4 +12,8 @@ import org.springframework.stereotype.Component;
 public class NcpImageProperties {
     private String path;
     private String type;
+
+    public String createImageUrl(String imageUrl) {
+        return String.format("%s%s%s", path, imageUrl, type);
+    }
 }

--- a/src/main/java/com/farmdora/farmdora/entity/Seller.java
+++ b/src/main/java/com/farmdora/farmdora/entity/Seller.java
@@ -8,7 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +28,7 @@ public class Seller {
     @Column(name = "seller_id")
     private Integer id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/opinion/repository/impl/CustomQuestionRepositoryImpl.java
@@ -4,7 +4,6 @@ import static com.farmdora.farmdora.entity.QQuestion.question;
 import static com.farmdora.farmdora.entity.QSale.sale;
 import static com.farmdora.farmdora.entity.QSeller.seller;
 
-import com.farmdora.farmdora.entity.QUser;
 import com.farmdora.farmdora.order.dto.SearchPeriod;
 import com.farmdora.farmdora.order.dto.SearchType;
 import com.farmdora.farmdora.order.dto.Sort;
@@ -47,6 +46,8 @@ public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
                         question.isProcess
                 ))
                 .from(question)
+                .join(question.sale, sale)
+                .join(sale.seller, seller)
                 .where(
                         sale.seller.user.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
@@ -60,18 +61,14 @@ public class CustomQuestionRepositoryImpl implements CustomQuestionRepository {
                 .fetch();
 
         log.info("문의 목록: {}", questions);
-        QUser sellerUser = new QUser("sellerUser");
-        QUser buyer = new QUser("buyer");
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(question.count())
                 .from(question)
                 .join(question.sale, sale)
-                .join(question.user, sellerUser)
                 .join(sale.seller, seller)
-                .join(seller.user, buyer)
                 .where(
-                        sellerUser.userId.eq(userId),
+                        seller.user.userId.eq(userId),
                         keywordContains(searchCondition.getSearchType(), searchCondition.getKeyword()),
                         dateBetween(searchCondition.getStartDate(), searchCondition.getEndDate(),
                                 searchCondition.getSearchPeriod()),

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -9,12 +9,12 @@ import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEW
 
 import com.farmdora.farmdora.common.response.HttpResponse;
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.CategorySearchRequestDto;
 import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
-import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.service.SaleService;
 import java.security.Principal;
@@ -27,7 +27,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -38,7 +37,10 @@ public class SaleController {
 
     @GetMapping("/{saleId}")
     public ResponseEntity<?> getSaleDetail(Principal principal, @PathVariable("saleId") Integer saleId) {
-        Integer userId = Integer.parseInt(principal.getName());
+        Integer userId = null;
+        if (principal != null) {
+            userId = Integer.parseInt(principal.getName());
+        }
         SaleDetailDto saleDetail = saleService.getSaleDetail(userId, saleId);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALE_DETAIL_SUCCESS.getMessage(), saleDetail));
@@ -83,12 +85,13 @@ public class SaleController {
 
     @GetMapping("/type")
     public ResponseEntity<?> getSalesByType(Principal principal,
-                                            @RequestParam(required = false) Short bigTypeId,
-                                            @RequestParam(required = false) Short typeId,
-                                            @RequestParam(required = false) SaleSortType sort,
+                                            CategorySearchRequestDto searchCondition,
                                             @PageableDefault(size = 20) Pageable pageable) {
-        Integer userId = Integer.parseInt(principal.getName());
-        PageResponseDto<SaleSummaryDto> sales = saleService.getSalesByCategory(userId, bigTypeId, typeId, sort, pageable);
+        Integer userId = null;
+        if (principal != null) {
+            userId = Integer.parseInt(principal.getName());
+        }
+        PageResponseDto<SaleSummaryDto> sales = saleService.getSalesByCategory(userId, searchCondition, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALES_BY_CATEGORIES.getMessage(), sales));
     }

--- a/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
+++ b/src/main/java/com/farmdora/farmdora/sale/controller/SaleController.java
@@ -71,8 +71,12 @@ public class SaleController {
     }
 
     @GetMapping("/rank")
-    public ResponseEntity<?> getSaleRank(@PageableDefault Pageable pageable) {
-        PageResponseDto<SaleRankingDto> sales = saleService.getTop50Sales(pageable);
+    public ResponseEntity<?> getSaleRank(Principal principal, @PageableDefault Pageable pageable) {
+        Integer userId = null;
+        if (principal != null) {
+            userId = Integer.parseInt(principal.getName());
+        }
+        PageResponseDto<SaleRankingDto> sales = saleService.getTop50Sales(userId, pageable);
         return ResponseEntity.ok()
                 .body(new HttpResponse(HttpStatus.OK, GET_SALES_RANK.getMessage(), sales));
     }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/CategorySearchRequestDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/CategorySearchRequestDto.java
@@ -1,0 +1,16 @@
+package com.farmdora.farmdora.sale.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CategorySearchRequestDto {
+    private String keyword;
+    private Short bigTypeId;
+    private Short typeId;
+    private SaleSortType sort;
+}

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleDetailDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleDetailDto.java
@@ -54,12 +54,14 @@ public class SaleDetailDto {
         private Integer optionId;
         private String optionName;
         private Integer price;
+        private Integer stock;
 
         public static OptionDetailDto createOptionDetail(Option option) {
             return OptionDetailDto.builder()
                     .optionId(option.getId())
                     .optionName(option.getName())
                     .price(option.getPrice())
+                    .stock(option.getQuantity())
                     .build();
         }
     }

--- a/src/main/java/com/farmdora/farmdora/sale/dto/SaleRankingDto.java
+++ b/src/main/java/com/farmdora/farmdora/sale/dto/SaleRankingDto.java
@@ -13,4 +13,14 @@ public class SaleRankingDto {
     private String title;
     private Integer minPrice;
     private Long orderCount;
+    private String imageUrl;
+    private boolean isLiked;
+
+    public SaleRankingDto(Integer saleId, String title, Integer minPrice, Long orderCount, String imageUrl) {
+        this.saleId = saleId;
+        this.title = title;
+        this.minPrice = minPrice;
+        this.orderCount = orderCount;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/CustomSaleRepository.java
@@ -1,10 +1,10 @@
 package com.farmdora.farmdora.sale.repository;
 
-import com.farmdora.farmdora.sale.dto.SaleSortType;
+import com.farmdora.farmdora.sale.dto.CategorySearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomSaleRepository {
-    Page<SaleSummaryDto> searchSalesByCategories(Integer userId, Short bigTypeId, Short typeId, SaleSortType sortType, Pageable pageable);
+    Page<SaleSummaryDto> searchSalesByCategories(Integer userId, CategorySearchRequestDto searchCondition, Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/LikeRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/LikeRepository.java
@@ -1,8 +1,14 @@
 package com.farmdora.farmdora.sale.repository;
 
 import com.farmdora.farmdora.entity.Like;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikeRepository extends JpaRepository<Like, Integer> {
     boolean existsByUserUserIdAndSaleId(Integer userId, Integer saleId);
+
+    @Query("SELECT l.sale.id FROM Like l WHERE l.user.userId = :userId")
+    Set<Integer> findSaleIdsByUserId(@Param("userId") Integer userId);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/SaleRepository.java
@@ -31,11 +31,13 @@ public interface SaleRepository extends JpaRepository<Sale, Integer>, CustomSell
             "s.id, " +
             "s.title, " +
             "MIN(o.price), " +
-            "COUNT(oo.id)) " +
+            "COUNT(oo.id), " +
+            "sf.saveFile) " +
             "FROM Sale s " +
             "JOIN Option o ON o.sale = s " +
             "JOIN OrderOption oo ON oo.option = o " +
-            "GROUP BY s.id, s.title " +
+            "LEFT JOIN SaleFile sf ON sf.sale = s AND sf.isMain = true " +
+            "GROUP BY s.id, s.title, sf.saveFile " +
             "ORDER BY COUNT(oo.id) DESC, s.id DESC")
     Page<SaleRankingDto> findTop50ByOrderCount(Pageable pageable);
 }

--- a/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
+++ b/src/main/java/com/farmdora/farmdora/sale/repository/impl/CustomSaleRepositoryImpl.java
@@ -7,12 +7,14 @@ import static com.farmdora.farmdora.entity.QReview.review;
 import static com.farmdora.farmdora.entity.QSale.sale;
 import static com.farmdora.farmdora.entity.QSaleFile.saleFile;
 
+import com.farmdora.farmdora.sale.dto.CategorySearchRequestDto;
 import com.farmdora.farmdora.sale.dto.QSaleSummaryDto;
 import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.repository.CustomSaleRepository;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,6 +23,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
 
 public class CustomSaleRepositoryImpl implements CustomSaleRepository {
 
@@ -31,29 +34,34 @@ public class CustomSaleRepositoryImpl implements CustomSaleRepository {
     }
 
     @Override
-    public Page<SaleSummaryDto> searchSalesByCategories(Integer userId, Short bigTypeId, Short typeId,
-                                                        SaleSortType sortType, Pageable pageable) {
+    public Page<SaleSummaryDto> searchSalesByCategories(Integer userId, CategorySearchRequestDto searchCondition, Pageable pageable) {
         List<SaleSummaryDto> sales = queryFactory
                 .select(new QSaleSummaryDto(
                         sale.id,
                         sale.title,
                         option.price.min(),
-                        JPAExpressions
-                                .selectOne()
-                                .from(like)
-                                .where(like.sale.eq(sale)
-                                        .and(like.user.userId.eq(userId)))
-                                .exists(),
-                        saleFile.saveFile.max()))
+                        userId != null ?
+                                JPAExpressions
+                                        .selectOne()
+                                        .from(like)
+                                        .where(like.sale.eq(sale)
+                                                .and(like.user.userId.eq(userId)))
+                                        .exists() :
+                                Expressions.FALSE,
+                        saleFile.saveFile.max()
+                ))
                 .from(sale)
                 .leftJoin(option).on(option.sale.eq(sale))
                 .leftJoin(orderOption).on(orderOption.option.eq(option))
                 .leftJoin(review).on(review.sale.eq(sale))
                 .leftJoin(saleFile).on(saleFile.sale.eq(sale).and(saleFile.isMain.isTrue()))
                 .leftJoin(like).on(like.sale.eq(sale))
-                .where(categoryCondition(typeId, bigTypeId))
+                .where(
+                        keywordContains(searchCondition.getKeyword()),
+                        categoryCondition(searchCondition.getTypeId(), searchCondition.getBigTypeId())
+                )
                 .groupBy(sale.id, sale.title)
-                .orderBy(getSaleOrderSpecifier(sortType), sale.id.desc())
+                .orderBy(getSaleOrderSpecifier(searchCondition.getSort()), sale.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -61,9 +69,16 @@ public class CustomSaleRepositoryImpl implements CustomSaleRepository {
         JPAQuery<Long> countQuery = queryFactory
                 .select(sale.count())
                 .from(sale)
-                .where(categoryCondition(typeId, bigTypeId));
+                .where(categoryCondition(searchCondition.getTypeId(), searchCondition.getBigTypeId()));
 
         return PageableExecutionUtils.getPage(sales, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        if (StringUtils.hasText(keyword)) {
+            return sale.title.contains(keyword);
+        }
+        return null;
     }
 
     private BooleanExpression categoryCondition(Short typeId, Short bigTypeId) {
@@ -79,6 +94,10 @@ public class CustomSaleRepositoryImpl implements CustomSaleRepository {
     }
 
     private OrderSpecifier<?> getSaleOrderSpecifier(SaleSortType sort) {
+        if (sort == null) {
+            return sale.id.desc();
+        }
+
         return switch (sort) {
             case ORDER_DESC -> orderOption.id.count().desc();
             case ORDER_ASC -> orderOption.id.count().asc();

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleRedisService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleRedisService.java
@@ -2,8 +2,10 @@ package com.farmdora.farmdora.sale.service;
 
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.repository.SaleRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -20,10 +22,11 @@ public class SaleRedisService {
 
     private final SaleRepository saleRepository;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper om;
 
     private static final int SEARCH_SIZE = 50;
     private static final int PAGE_SIZE = 10;
-    private static final int POPULAR_SALES_DURATION = 10;
+    private static final int POPULAR_SALES_DURATION = 30;
     private static final String POPULAR_SALES_KEY = "popular:sales:page:";
     private static final String POPULAR_SALES_COUNT_KEY = "popular:sales:count";
 
@@ -33,10 +36,9 @@ public class SaleRedisService {
 
         Pageable pageable = PageRequest.of(0, SEARCH_SIZE);
         Page<SaleRankingDto> sales = saleRepository.findTop50ByOrderCount(pageable);
-        redisTemplate.opsForValue().set(POPULAR_SALES_COUNT_KEY, sales.getTotalElements(), Duration.ofMinutes(10));
-
         List<SaleRankingDto> content = sales.getContent();
         int total = content.size();
+        redisTemplate.opsForValue().set(POPULAR_SALES_COUNT_KEY, total, Duration.ofMinutes(10));
 
         for (int page = 0; page < (total + PAGE_SIZE - 1) / PAGE_SIZE; page++) {
             int start = page * PAGE_SIZE;
@@ -51,7 +53,15 @@ public class SaleRedisService {
     }
 
     public List<SaleRankingDto> findSaleRanks(int page) {
-        return (List<SaleRankingDto>) redisTemplate.opsForValue().get(POPULAR_SALES_COUNT_KEY + (page + 1));
+        log.info("인기 상품 목록을 캐시에서 조회합니다.");
+
+        Object cachedSalesValue = redisTemplate.opsForValue().get(POPULAR_SALES_KEY + page);
+        if (cachedSalesValue == null) return null;
+
+        List<?> cachedSales = (List<?>) cachedSalesValue;
+        return cachedSales.stream()
+                .map(obj -> om.convertValue(obj, SaleRankingDto.class))
+                .collect(Collectors.toList());
     }
 
     public Integer findSaleRankCount() {

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -10,13 +10,13 @@ import com.farmdora.farmdora.entity.Sale;
 import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import com.farmdora.farmdora.opinion.repository.ReviewRepository;
+import com.farmdora.farmdora.sale.dto.CategorySearchRequestDto;
 import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedInfoDto;
-import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import com.farmdora.farmdora.sale.repository.LikeRepository;
 import com.farmdora.farmdora.sale.repository.OptionRepository;
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -51,14 +50,7 @@ public class SaleService {
     private final QuestionRepository questionRepository;
     private final SaleRedisService saleRedisService;
     private final ReviewFileRepository reviewFileRepository;
-
     private final NcpImageProperties imageProperties;
-
-    @Value("${ncp.image.path}")
-    private String imagePath;
-
-    @Value("${ncp.image.type}")
-    private String type;
 
     @Transactional(readOnly = true)
     public SaleDetailDto getSaleDetail(Integer userId, Integer saleId) {
@@ -80,7 +72,7 @@ public class SaleService {
         return saleImages.stream()
                 .map(file -> SaleFile.builder()
                         .id(file.getId())
-                        .saveFile(String.format("%s%s%s", imagePath, file.getSaveFile(), type))
+                        .saveFile(imageProperties.createImageUrl(file.getSaveFile()))
                         .sale(file.getSale())
                         .isMain(file.isMain())
                         .originFile(file.getOriginFile())
@@ -114,7 +106,7 @@ public class SaleService {
     private String getMainImage(Optional<SaleFile> saleFile) {
         String mainImage = null;
         if (saleFile.isPresent()) {
-            mainImage = String.format("%s%s%s", imagePath, saleFile.get().getSaveFile(), type);
+            mainImage = imageProperties.createImageUrl(saleFile.get().getSaveFile());
         }
         return mainImage;
     }
@@ -144,7 +136,7 @@ public class SaleService {
                                 .stream()
                                 .map(f -> ReviewFile.builder()
                                         .id(f.getId())
-                                        .saveFile(String.format("%s%s%s", imagePath, f.getSaveFile(), type))
+                                        .saveFile(imageProperties.createImageUrl(f.getSaveFile()))
                                         .review(f.getReview())
                                         .build()
                                 ).collect(Collectors.toList())
@@ -196,9 +188,9 @@ public class SaleService {
             likedSaleIds = likeRepository.findSaleIdsByUserId(userId);
         }
 
-        for (SaleRankingDto dto : dtos) {
-            dto.setLiked(userId != null && likedSaleIds.contains(dto.getSaleId()));
-            dto.setImageUrl(imageProperties.getPath() + dto.getImageUrl() + imageProperties.getType());
+        for (SaleRankingDto sale : dtos) {
+            sale.setLiked(userId != null && likedSaleIds.contains(sale.getSaleId()));
+            sale.setImageUrl(imageProperties.createImageUrl(sale.getImageUrl()));
         }
 
         Page<SaleRankingDto> page = new PageImpl<>(dtos, pageable, totalElements);
@@ -206,12 +198,14 @@ public class SaleService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponseDto<SaleSummaryDto> getSalesByCategory(Integer userId, Short bigTypeId, Short typeId, SaleSortType sortType, Pageable pageable) {
-        Page<SaleSummaryDto> sales = saleRepository.searchSalesByCategories(userId, bigTypeId, typeId, sortType, pageable);
+    public PageResponseDto<SaleSummaryDto> getSalesByCategory(Integer userId,
+                                                              CategorySearchRequestDto searchCondition,
+                                                              Pageable pageable) {
+        Page<SaleSummaryDto> sales = saleRepository.searchSalesByCategories(userId, searchCondition, pageable);
 
         sales.getContent().forEach(s -> {
             if (s.getMainImage() != null) {
-                s.setMainImage(imagePath + s.getMainImage() + type);
+                s.setMainImage(imageProperties.createImageUrl(s.getMainImage()));
             }
         });
 

--- a/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
+++ b/src/main/java/com/farmdora/farmdora/sale/service/SaleService.java
@@ -1,5 +1,6 @@
 package com.farmdora.farmdora.sale.service;
 
+import com.farmdora.farmdora.common.NcpImageProperties;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.entity.Option;
@@ -26,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,6 +51,8 @@ public class SaleService {
     private final QuestionRepository questionRepository;
     private final SaleRedisService saleRedisService;
     private final ReviewFileRepository reviewFileRepository;
+
+    private final NcpImageProperties imageProperties;
 
     @Value("${ncp.image.path}")
     private String imagePath;
@@ -160,22 +164,45 @@ public class SaleService {
     }
 
     @Transactional(readOnly = true)
-    public PageResponseDto<SaleRankingDto> getTop50Sales(Pageable pageable) {
+    public PageResponseDto<SaleRankingDto> getTop50Sales(Integer userId, Pageable pageable) {
         List<SaleRankingDto> cachedSaleRanks = saleRedisService.findSaleRanks(pageable.getPageNumber());
         Integer count = saleRedisService.findSaleRankCount();
 
         if (cachedSaleRanks == null || cachedSaleRanks.isEmpty() || count == null) {
             log.info("캐시된 데이터가 존재하지 않습니다...DB를 조회합니다...");
-            return getTop50SalesFromDb(pageable);
+            return getTop50SalesFromDb(userId, pageable);
         }
 
-        Page<SaleRankingDto> sales = new PageImpl<>(cachedSaleRanks, pageable, count);
-        return new PageResponseDto<>(sales.getContent(), sales);
+        return toPageResponseWithLikeAndImage(cachedSaleRanks, count, userId, pageable);
     }
 
-    private PageResponseDto<SaleRankingDto> getTop50SalesFromDb(Pageable pageable) {
+    private PageResponseDto<SaleRankingDto> getTop50SalesFromDb(Integer userId, Pageable pageable) {
         Page<SaleRankingDto> sales = saleRepository.findTop50ByOrderCount(pageable);
-        return new PageResponseDto<>(sales.getContent(), sales);
+        List<SaleRankingDto> content = sales.getContent();
+
+        long totalElements = Math.min(50L, content.size());
+
+        return toPageResponseWithLikeAndImage(content, totalElements, userId, pageable);
+    }
+
+    private PageResponseDto<SaleRankingDto> toPageResponseWithLikeAndImage(
+            List<SaleRankingDto> dtos,
+            long totalElements,
+            Integer userId,
+            Pageable pageable) {
+
+        Set<Integer> likedSaleIds = Set.of();
+        if (userId != null) {
+            likedSaleIds = likeRepository.findSaleIdsByUserId(userId);
+        }
+
+        for (SaleRankingDto dto : dtos) {
+            dto.setLiked(userId != null && likedSaleIds.contains(dto.getSaleId()));
+            dto.setImageUrl(imageProperties.getPath() + dto.getImageUrl() + imageProperties.getType());
+        }
+
+        Page<SaleRankingDto> page = new PageImpl<>(dtos, pageable, totalElements);
+        return new PageResponseDto<>(dtos, page);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ENC(hp01SRpbCL4Faie2JeNAaCLNzAdcibZl4h/kcYuw27lBroKfwj+3qYyR0464gApzKx+0EIXhK0vgs35lMwW6iSJ5NXjMx7In)
+    username: ENC(DHRmOlZ8bg4K57q2F3j4oFrGjrudIQu3)
+    password: ENC(wcEiMtZdcspXjQt3JXr6kus48hFneUJZ)
+
+  # redis

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,4 +5,7 @@ spring:
     username: ENC(DHRmOlZ8bg4K57q2F3j4oFrGjrudIQu3)
     password: ENC(wcEiMtZdcspXjQt3JXr6kus48hFneUJZ)
 
-  # redis
+  data:
+    redis:
+      host: ENC(VFdUc/6tLyxg23xcLaVduyy/WRypzmZy)
+      port: 6379

--- a/src/test/java/com/farmdora/farmdora/admin/repository/CustomUserRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/admin/repository/CustomUserRepositoryTest.java
@@ -32,16 +32,21 @@ class CustomUserRepositoryTest {
         // given
         for (int i = 1; i <= 15; i++) {
             User user = User.builder()
+                    .id("user" + i)
                     .name("user" + i)
                     .isBlind(false)
                     .build();
             em.persist(user);
 
             if (i % 2 == 0) {
-                Seller seller = Seller.builder()
+                Seller seller1 = Seller.builder()
                         .user(user)
                         .build();
-                em.persist(seller);
+                em.persist(seller1);
+                Seller seller2 = Seller.builder()
+                        .user(user)
+                        .build();
+                em.persist(seller2);
             }
         }
 

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -9,7 +9,6 @@ import static com.farmdora.farmdora.common.response.SuccessMessage.SEARCH_REVIEW
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -18,13 +17,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.farmdora.farmdora.ControllerTest;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
+import com.farmdora.farmdora.sale.dto.CategorySearchRequestDto;
 import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto.OptionDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleRankingDto;
 import com.farmdora.farmdora.sale.dto.SaleRelatedDto;
-import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -251,7 +250,7 @@ public class SaleControllerTest extends ControllerTest {
         sales.setCurrentPage(0);
         sales.setPageSize(10);
         sales.setTotalElements(100L);
-        when(saleService.getSalesByCategory(anyInt(), anyShort(), anyShort(), any(SaleSortType.class), any(Pageable.class))).thenReturn(sales);
+        when(saleService.getSalesByCategory(anyInt(), any(CategorySearchRequestDto.class), any(Pageable.class))).thenReturn(sales);
 
         // when
         // then

--- a/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/controller/SaleControllerTest.java
@@ -225,7 +225,7 @@ public class SaleControllerTest extends ControllerTest {
         sales.setCurrentPage(0);
         sales.setPageSize(10);
         sales.setTotalElements(100L);
-        when(saleService.getTop50Sales(any(Pageable.class))).thenReturn(sales);
+        when(saleService.getTop50Sales(anyInt(), any(Pageable.class))).thenReturn(sales);
 
         // when
         // then

--- a/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/repository/CustomSaleRepositoryTest.java
@@ -12,6 +12,7 @@ import com.farmdora.farmdora.entity.SaleFile;
 import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.entity.SaleTypeBig;
 import com.farmdora.farmdora.entity.User;
+import com.farmdora.farmdora.sale.dto.CategorySearchRequestDto;
 import com.farmdora.farmdora.sale.dto.SaleSortType;
 import com.farmdora.farmdora.sale.dto.SaleSummaryDto;
 import org.junit.jupiter.api.DisplayName;
@@ -101,7 +102,6 @@ class CustomSaleRepositoryTest {
                     .build();
             em.persist(orderOption1);
 
-            // 짝수번이 주문수가 가장 많음
             if (i % 2 == 0) {
                 OrderOption orderOption2 = OrderOption.builder()
                         .order(order2)
@@ -110,7 +110,6 @@ class CustomSaleRepositoryTest {
                 em.persist(orderOption2);
             }
 
-            // 짝수번이 좋아요수가 가장 많음
             if (i % 2 == 0) {
                 em.persist(Like.builder()
                         .sale(sale)
@@ -124,10 +123,37 @@ class CustomSaleRepositoryTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        Page<SaleSummaryDto> salesByType = saleRepository.searchSalesByCategories(user1.getUserId(), bigType.getId(), type.getId(), SaleSortType.PRICE_DESC, pageable);
-        Page<SaleSummaryDto> salesByBigType = saleRepository.searchSalesByCategories(user1.getUserId(), bigType.getId(), null, SaleSortType.ORDER_DESC, pageable);
-        Page<SaleSummaryDto> salesByNoType = saleRepository.searchSalesByCategories(user1.getUserId(),null, null, SaleSortType.REVIEW_DESC, pageable);
-        Page<SaleSummaryDto> salesByLikeCount = saleRepository.searchSalesByCategories(user1.getUserId(),null, null, SaleSortType.RECOMMEND, pageable);
+        CategorySearchRequestDto searchCondition1 = CategorySearchRequestDto.builder()
+                .keyword(null)
+                .typeId(type.getId())
+                .bigTypeId(bigType.getId())
+                .sort(SaleSortType.PRICE_DESC)
+                .build();
+        Page<SaleSummaryDto> salesByType = saleRepository.searchSalesByCategories(user1.getUserId(), searchCondition1, pageable);
+
+        CategorySearchRequestDto searchCondition2 = CategorySearchRequestDto.builder()
+                .keyword(null)
+                .typeId(null)
+                .bigTypeId(bigType.getId())
+                .sort(SaleSortType.ORDER_DESC)
+                .build();
+        Page<SaleSummaryDto> salesByBigType = saleRepository.searchSalesByCategories(user1.getUserId(), searchCondition2, pageable);
+
+        CategorySearchRequestDto searchCondition3 = CategorySearchRequestDto.builder()
+                .keyword(null)
+                .typeId(null)
+                .bigTypeId(null)
+                .sort(SaleSortType.REVIEW_DESC)
+                .build();
+        Page<SaleSummaryDto> salesByNoType = saleRepository.searchSalesByCategories(user1.getUserId(), searchCondition3, pageable);
+
+        CategorySearchRequestDto searchCondition4 = CategorySearchRequestDto.builder()
+                .keyword(null)
+                .typeId(null)
+                .bigTypeId(null)
+                .sort(SaleSortType.RECOMMEND)
+                .build();
+        Page<SaleSummaryDto> salesByLikeCount = saleRepository.searchSalesByCategories(user1.getUserId(), searchCondition4, pageable);
 
         // then
         assertThat(salesByType.getContent().size()).isEqualTo(10);

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleRedisServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleRedisServiceTest.java
@@ -43,7 +43,7 @@ class SaleRedisServiceTest {
     void testCachePopularSales() {
         // given
         List<SaleRankingDto> dummyList = IntStream.rangeClosed(1, 50)
-                .mapToObj(i -> new SaleRankingDto(i, "상품" + i, i * 1000, null))
+                .mapToObj(i -> new SaleRankingDto(i, "상품" + i, i * 1000, null, "imageUrl"))
                 .toList();
         Page<SaleRankingDto> dummyPage = new PageImpl<>(dummyList);
 

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -22,6 +22,7 @@ import com.farmdora.farmdora.entity.SaleType;
 import com.farmdora.farmdora.entity.User;
 import com.farmdora.farmdora.opinion.repository.QuestionRepository;
 import com.farmdora.farmdora.opinion.repository.ReviewRepository;
+import com.farmdora.farmdora.sale.dto.CategorySearchRequestDto;
 import com.farmdora.farmdora.sale.dto.QuestionResponseDto;
 import com.farmdora.farmdora.sale.dto.ReviewDetailDto;
 import com.farmdora.farmdora.sale.dto.SaleDetailDto;
@@ -387,12 +388,16 @@ class SaleServiceTest {
         );
         Pageable pageable = PageRequest.of(0, 10);
         PageImpl<SaleSummaryDto> sales = new PageImpl<>(saleSummaries, pageable, 2);
-        when(saleRepository.searchSalesByCategories(anyInt(), anyShort(), anyShort(), any(SaleSortType.class), any(Pageable.class))).thenReturn(sales);
+        when(saleRepository.searchSalesByCategories(anyInt(), any(CategorySearchRequestDto.class), any(Pageable.class))).thenReturn(sales);
 
         // when
-        Short bigTypeId = 1;
-        Short typeId = 2;
-        PageResponseDto<SaleSummaryDto> result = saleService.getSalesByCategory(1, bigTypeId, typeId, SaleSortType.PRICE_DESC, pageable);
+        CategorySearchRequestDto searchCondition = CategorySearchRequestDto.builder()
+                .keyword(null)
+                .typeId(Short.valueOf("1"))
+                .bigTypeId(Short.valueOf("2"))
+                .sort(SaleSortType.PRICE_DESC)
+                .build();
+        PageResponseDto<SaleSummaryDto> result = saleService.getSalesByCategory(1, searchCondition, pageable);
 
         // then
         assertThat(result.getContents().size()).isEqualTo(2);

--- a/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/farmdora/farmdora/sale/service/SaleServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.farmdora.farmdora.common.NcpImageProperties;
 import com.farmdora.farmdora.common.exception.ResourceNotFoundException;
 import com.farmdora.farmdora.common.response.PageResponseDto;
 import com.farmdora.farmdora.entity.Option;
@@ -38,6 +39,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -76,6 +78,9 @@ class SaleServiceTest {
 
     @Mock
     private SaleRedisService saleRedisService;
+
+    @Mock
+    private NcpImageProperties imageProperties;
 
     @InjectMocks
     private SaleService saleService;
@@ -331,8 +336,10 @@ class SaleServiceTest {
         Page<SaleRankingDto> saleRanks = new PageImpl<>(sales, pageable, 2);
         when(saleRepository.findTop50ByOrderCount(pageable)).thenReturn(saleRanks);
 
+        when(likeRepository.findSaleIdsByUserId(anyInt())).thenReturn(Set.of(1, 2, 3, 4));
+
         // when
-        PageResponseDto<SaleRankingDto> result = saleService.getTop50Sales(pageable);
+        PageResponseDto<SaleRankingDto> result = saleService.getTop50Sales(1, pageable);
 
         // then
         assertThat(result.getContents().size()).isEqualTo(2);
@@ -353,7 +360,7 @@ class SaleServiceTest {
 
         // when
         Pageable pageable = PageRequest.of(0, 10);
-        PageResponseDto<SaleRankingDto> result = saleService.getTop50Sales(pageable);
+        PageResponseDto<SaleRankingDto> result = saleService.getTop50Sales(1, pageable);
 
         // then
         verify(saleRepository, times(0)).findTop50ByOrderCount(pageable);


### PR DESCRIPTION
## 📌 작업 내용
- [x] 인기상품목록 조회 수정(메인이미지, 찜 여부 포함)
- [x] 관리자의 사용자 목록 검색 QueryDsl 수정
- [x] 판매자의 문의 목록 검색 QueryDsl 수정
- [x] 상품 상세 조회시 각 옵션의 재고수를 같이 조회하도록 수정
- [x] 운영 DB 설정 추가
- [x] 운영 Redis 설정 추가
- [x] Seller 엔티티 수정
- [x] 테스트 케이스 수정

<br>

## 💡 필수확인
- 인기상품목록 조회시 메인이미지, 찜 여부를 포함하여 응답
- Seller엔티티의 User 연관관계를 `OneToOne` -> `ManyToOne`으로 변경

<br>

## 📆 작업기간
2025.05.04